### PR TITLE
Add optional argument `tail --file FILENAME` to accept logs from one or more files

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,47 @@ update_status ❯──┼┘
 
 And did I mention that there's **colors**?
 
+### You can also `tail` saved logs
+
+Say you have saved two debug-logs with:
+
+```
+juju debug-log --date -i prom/0 > prom.log
+juju debug-log --date -i trfk/0 > trfk.log
+```
+
+Yielding files:
+
+prom.txt
+```
+unit-prom-0: 2022-07-20 10:00:00 INFO juju.worker.uniter.operation ran "install" hook (via hook dispatching script: dispatch)
+unit-prom-0: 2022-07-21 5:00:00 INFO juju.worker.uniter.operation ran "prometheus-peers-relation-created" hook (via hook dispatching script: dispatch)
+```
+
+trfk.txt
+```
+unit-trfk-0: 2022-07-20 11:00:00 INFO juju.worker.uniter.operation ran "start" hook (via hook dispatching script: dispatch)
+unit-trfk-0: 2022-07-20 12:00:00 INFO juju.worker.uniter.operation ran "traefik-pebble-ready" hook (via hook dispatching script: dispatch)
+```
+
+You can run `jhack utils tail --file=prom.txt --file=trfk.txt` to see the events in all the logs, interlaced in the correct chronological order as expected:
+
+```
+┏━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ timestamp      ┃ prom/0                               ┃ trfk/0                  ┃
+┡━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│  5:00:00       │ prometheus_peers_relation_created    │                         │
+│ 12:00:00       │                                      │ traefik_pebble_ready    │
+│ 11:00:00       │                                      │ start                   │
+│ 10:00:00       │ install                              │                         │
+├────────────────┼──────────────────────────────────────┼─────────────────────────┤
+│ The end.       │ prom/0                               │ trfk/0                  │
+├────────────────┼──────────────────────────────────────┼─────────────────────────┤
+│ events emitted │ 2                                    │ 2                       │
+└────────────────┴──────────────────────────────────────┴─────────────────────────┘
+```
+
+
 ## show-relation 
 
 Displays the databags of units involved in a relation.

--- a/jhack/tests/utils/tail_mocks/interlace-log-0.txt
+++ b/jhack/tests/utils/tail_mocks/interlace-log-0.txt
@@ -1,0 +1,5 @@
+debuglog-0: 2022-07-20 12:24:26 INFO juju.worker.apicaller [241733] "controller-0" successfully connected to "localhost:17070"
+debuglog-0: 2022-07-21 12:24:26 INFO juju.worker.logforwarder config change - log forwarding not enabled
+debuglog-0: 2022-07-21 13:24:26 INFO juju.worker.logger logger worker started
+debuglog-0: 2022-07-21 16:24:26 INFO juju.worker.pruner.action status history config: max age: 336h0m0s, max collection size 5120M for kubeflow (241733e9-d6d3-4922-87df-e301d04aedeb)
+debuglog-0: 2022-07-22 12:24:26 INFO juju.worker.pruner.statushistory status history config: max age: 336h0m0s, max collection size 5120M for kubeflow (241733e9-d6d3-4922-87df-e301d04aedeb)

--- a/jhack/tests/utils/tail_mocks/interlace-log-1.txt
+++ b/jhack/tests/utils/tail_mocks/interlace-log-1.txt
@@ -1,0 +1,5 @@
+debuglog-1: 2022-07-20 13:24:26 INFO juju.worker.apicaller [241733] "controller-0" successfully connected to "localhost:17070"
+debuglog-1: 2022-07-21 1:24:26 INFO juju.worker.logforwarder config change - log forwarding not enabled
+debuglog-1: 2022-07-22 1:24:26 INFO juju.worker.logger logger worker started
+debuglog-1: 2022-07-22 2:24:26 INFO juju.worker.pruner.action status history config: max age: 336h0m0s, max collection size 5120M for kubeflow (241733e9-d6d3-4922-87df-e301d04aedeb)
+debuglog-1: 2022-07-22 22:24:26 INFO juju.worker.pruner.statushistory status history config: max age: 336h0m0s, max collection size 5120M for kubeflow (241733e9-d6d3-4922-87df-e301d04aedeb)

--- a/jhack/tests/utils/tail_mocks/interlace-log-combined.txt
+++ b/jhack/tests/utils/tail_mocks/interlace-log-combined.txt
@@ -1,0 +1,10 @@
+debuglog-0: 2022-07-20 12:24:26 INFO juju.worker.apicaller [241733] "controller-0" successfully connected to "localhost:17070"
+debuglog-1: 2022-07-20 13:24:26 INFO juju.worker.apicaller [241733] "controller-0" successfully connected to "localhost:17070"
+debuglog-1: 2022-07-21 1:24:26 INFO juju.worker.logforwarder config change - log forwarding not enabled
+debuglog-0: 2022-07-21 12:24:26 INFO juju.worker.logforwarder config change - log forwarding not enabled
+debuglog-0: 2022-07-21 13:24:26 INFO juju.worker.logger logger worker started
+debuglog-0: 2022-07-21 16:24:26 INFO juju.worker.pruner.action status history config: max age: 336h0m0s, max collection size 5120M for kubeflow (241733e9-d6d3-4922-87df-e301d04aedeb)
+debuglog-1: 2022-07-22 1:24:26 INFO juju.worker.logger logger worker started
+debuglog-1: 2022-07-22 2:24:26 INFO juju.worker.pruner.action status history config: max age: 336h0m0s, max collection size 5120M for kubeflow (241733e9-d6d3-4922-87df-e301d04aedeb)
+debuglog-0: 2022-07-22 12:24:26 INFO juju.worker.pruner.statushistory status history config: max age: 336h0m0s, max collection size 5120M for kubeflow (241733e9-d6d3-4922-87df-e301d04aedeb)
+debuglog-1: 2022-07-22 22:24:26 INFO juju.worker.pruner.statushistory status history config: max age: 336h0m0s, max collection size 5120M for kubeflow (241733e9-d6d3-4922-87df-e301d04aedeb)

--- a/jhack/tests/utils/tail_mocks/interlace-log-no-date.txt
+++ b/jhack/tests/utils/tail_mocks/interlace-log-no-date.txt
@@ -1,0 +1,5 @@
+debuglog-0: 12:24:26 INFO juju.worker.apicaller [241733] "controller-0" successfully connected to "localhost:17070"
+debuglog-0: 12:24:26 INFO juju.worker.logforwarder config change - log forwarding not enabled
+debuglog-0: 13:24:26 INFO juju.worker.logger logger worker started
+debuglog-0: 16:24:26 INFO juju.worker.pruner.action status history config: max age: 336h0m0s, max collection size 5120M for kubeflow (241733e9-d6d3-4922-87df-e301d04aedeb)
+debuglog-0: 12:24:26 INFO juju.worker.pruner.statushistory status history config: max age: 336h0m0s, max collection size 5120M for kubeflow (241733e9-d6d3-4922-87df-e301d04aedeb)

--- a/jhack/tests/utils/tail_mocks/real-prom-cropped-for-interlace.txt
+++ b/jhack/tests/utils/tail_mocks/real-prom-cropped-for-interlace.txt
@@ -1,0 +1,42 @@
+unit-prom-0: 2022-07-20 15:34:06 INFO juju.cmd running containerAgent [2.9.32 c360f3d92b40458cf15512a7fe5eddb0e7ae57b2 gc go1.18.3]
+unit-prom-0: 2022-07-20 15:34:06 INFO juju.cmd.containeragent.unit start "unit"
+unit-prom-0: 2022-07-20 15:34:06 INFO juju.worker.upgradesteps upgrade steps for 2.9.32 have already been run.
+unit-prom-0: 2022-07-20 15:34:06 INFO juju.worker.probehttpserver starting http server on [::]:3856
+unit-prom-0: 2022-07-20 15:34:06 INFO juju.api connection established to "wss://controller-service.controller-uk8sx.svc.cluster.local:17070/model/241733e9-d6d3-4922-87df-e301d04aedeb/api"
+unit-prom-0: 2022-07-20 15:34:06 INFO juju.worker.apicaller [241733] "unit-prom-0" successfully connected to "controller-service.controller-uk8sx.svc.cluster.local:17070"
+unit-prom-0: 2022-07-20 15:34:06 INFO juju.api cannot resolve "controller-service.controller-uk8sx.svc.cluster.local": lookup controller-service.controller-uk8sx.svc.cluster.local: operation was canceled
+unit-prom-0: 2022-07-20 15:34:06 INFO juju.api connection established to "wss://10.152.183.197:17070/model/241733e9-d6d3-4922-87df-e301d04aedeb/api"
+unit-prom-0: 2022-07-20 15:34:06 INFO juju.worker.apicaller [241733] "unit-prom-0" successfully connected to "10.152.183.197:17070"
+unit-prom-0: 2022-07-20 15:34:06 INFO juju.worker.migrationminion migration phase is now: NONE
+unit-prom-0: 2022-07-20 15:34:06 INFO juju.worker.logger logger worker started
+unit-prom-0: 2022-07-20 15:34:06 WARNING juju.worker.proxyupdater unable to set snap core settings [proxy.http= proxy.https= proxy.store=]: exec: "snap": executable file not found in $PATH, output: ""
+unit-prom-0: 2022-07-20 15:34:06 INFO juju.worker.leadership prom/0 promoted to leadership of prom
+unit-prom-0: 2022-07-20 15:34:06 INFO juju.worker.caasupgrader abort check blocked until version event received
+unit-prom-0: 2022-07-20 15:34:06 INFO juju.worker.caasupgrader unblocking abort check
+unit-prom-0: 2022-07-20 15:34:06 INFO juju.agent.tools ensure jujuc symlinks in /var/lib/juju/tools/unit-prom-0
+unit-prom-0: 2022-07-20 15:34:06 INFO juju.worker.uniter unit "prom/0" started
+unit-prom-0: 2022-07-20 15:34:06 INFO juju.worker.uniter resuming charm install
+unit-prom-0: 2022-07-20 15:34:06 INFO juju.worker.uniter.charm downloading ch:amd64/focal/prometheus-k8s-51 from API server
+unit-prom-0: 2022-07-20 15:34:06 INFO juju.downloader downloading from ch:amd64/focal/prometheus-k8s-51
+unit-prom-0: 2022-07-20 15:34:06 INFO juju.downloader download complete ("ch:amd64/focal/prometheus-k8s-51")
+unit-prom-0: 2022-07-20 15:34:06 INFO juju.downloader download verified ("ch:amd64/focal/prometheus-k8s-51")
+unit-prom-0: 2022-07-20 15:34:13 INFO juju.worker.uniter hooks are retried true
+unit-prom-0: 2022-07-20 15:34:14 INFO juju.worker.uniter found queued "install" hook
+unit-prom-0: 2022-07-20 15:34:15 INFO unit.prom/0.juju-log Running legacy hooks/install.
+unit-prom-0: 2022-07-20 15:34:15 INFO unit.prom/0.juju-log Kubernetes service 'prom' patched successfully
+unit-prom-0: 2022-07-20 15:34:16 INFO juju.worker.uniter.operation ran "install" hook (via hook dispatching script: dispatch)
+unit-prom-0: 2022-07-20 15:34:17 INFO juju.worker.uniter.operation ran "prometheus-peers-relation-created" hook (via hook dispatching script: dispatch)
+unit-prom-0: 2022-07-20 15:34:17 INFO juju.worker.uniter found queued "leader-elected" hook
+unit-prom-0: 2022-07-20 15:34:18 INFO juju.worker.uniter.operation ran "leader-elected" hook (via hook dispatching script: dispatch)
+unit-prom-0: 2022-07-20 15:34:19 INFO juju.worker.uniter.operation ran "database-storage-attached" hook (via hook dispatching script: dispatch)
+unit-prom-0: 2022-07-20 15:34:20 INFO juju.worker.uniter.operation ran "config-changed" hook (via hook dispatching script: dispatch)
+unit-prom-0: 2022-07-20 15:34:20 INFO juju.worker.uniter found queued "start" hook
+unit-prom-0: 2022-07-20 15:34:20 INFO unit.prom/0.juju-log Running legacy hooks/start.
+unit-prom-0: 2022-07-20 15:34:21 INFO juju.worker.uniter.operation ran "start" hook (via hook dispatching script: dispatch)
+unit-prom-0: 2022-07-20 15:35:14 INFO unit.prom/0.juju-log Pushed new configuration
+unit-prom-0: 2022-07-20 15:35:15 INFO unit.prom/0.juju-log Prometheus (re)started
+unit-prom-0: 2022-07-20 15:35:16 INFO juju.worker.uniter.operation ran "prometheus-pebble-ready" hook (via hook dispatching script: dispatch)
+unit-prom-0: 2022-07-20 15:38:44 INFO juju.worker.uniter.operation ran "update-status" hook (via hook dispatching script: dispatch)
+unit-prom-0: 2022-07-20 15:44:29 INFO juju.worker.uniter.operation ran "update-status" hook (via hook dispatching script: dispatch)
+unit-prom-0: 2022-07-20 15:48:06 INFO juju.worker.uniter.operation ran "update-status" hook (via hook dispatching script: dispatch)
+unit-prom-0: 2022-07-20 15:48:11 INFO juju.worker.uniter.operation ran "update-status" hook (via hook dispatching script: dispatch)

--- a/jhack/tests/utils/tail_mocks/real-trfk-cropped-for-interlace.txt
+++ b/jhack/tests/utils/tail_mocks/real-trfk-cropped-for-interlace.txt
@@ -1,0 +1,36 @@
+unit-trfk-0: 2022-07-20 15:34:04 INFO juju.cmd running containerAgent [2.9.32 c360f3d92b40458cf15512a7fe5eddb0e7ae57b2 gc go1.18.3]
+unit-trfk-0: 2022-07-20 15:34:04 INFO juju.cmd.containeragent.unit start "unit"
+unit-trfk-0: 2022-07-20 15:34:04 INFO juju.worker.upgradesteps upgrade steps for 2.9.32 have already been run.
+unit-trfk-0: 2022-07-20 15:34:04 INFO juju.worker.probehttpserver starting http server on [::]:3856
+unit-trfk-0: 2022-07-20 15:34:05 INFO juju.api connection established to "wss://controller-service.controller-uk8sx.svc.cluster.local:17070/model/241733e9-d6d3-4922-87df-e301d04aedeb/api"
+unit-trfk-0: 2022-07-20 15:34:05 INFO juju.worker.apicaller [241733] "unit-trfk-0" successfully connected to "controller-service.controller-uk8sx.svc.cluster.local:17070"
+unit-trfk-0: 2022-07-20 15:34:05 INFO juju.worker.migrationminion migration phase is now: NONE
+unit-trfk-0: 2022-07-20 15:34:05 INFO juju.worker.logger logger worker started
+unit-trfk-0: 2022-07-20 15:34:05 WARNING juju.worker.proxyupdater unable to set snap core settings [proxy.http= proxy.https= proxy.store=]: exec: "snap": executable file not found in $PATH, output: ""
+unit-trfk-0: 2022-07-20 15:34:05 INFO juju.worker.leadership trfk/0 promoted to leadership of trfk
+unit-trfk-0: 2022-07-20 15:34:05 INFO juju.worker.caasupgrader abort check blocked until version event received
+unit-trfk-0: 2022-07-20 15:34:05 INFO juju.worker.caasupgrader unblocking abort check
+unit-trfk-0: 2022-07-20 15:34:05 INFO juju.agent.tools ensure jujuc symlinks in /var/lib/juju/tools/unit-trfk-0
+unit-trfk-0: 2022-07-20 15:34:05 INFO juju.worker.uniter unit "trfk/0" started
+unit-trfk-0: 2022-07-20 15:34:05 INFO juju.worker.uniter resuming charm install
+unit-trfk-0: 2022-07-20 15:34:05 INFO juju.worker.uniter.charm downloading ch:amd64/focal/traefik-k8s-10 from API server
+unit-trfk-0: 2022-07-20 15:34:05 INFO juju.downloader downloading from ch:amd64/focal/traefik-k8s-10
+unit-trfk-0: 2022-07-20 15:34:05 INFO juju.downloader download complete ("ch:amd64/focal/traefik-k8s-10")
+unit-trfk-0: 2022-07-20 15:34:05 INFO juju.downloader download verified ("ch:amd64/focal/traefik-k8s-10")
+unit-trfk-0: 2022-07-20 15:34:13 INFO juju.worker.uniter hooks are retried true
+unit-trfk-0: 2022-07-20 15:34:13 INFO juju.worker.uniter found queued "install" hook
+unit-trfk-0: 2022-07-20 15:34:15 INFO unit.trfk/0.juju-log Running legacy hooks/install.
+unit-trfk-0: 2022-07-20 15:34:16 INFO unit.trfk/0.juju-log Kubernetes service 'trfk' patched successfully
+unit-trfk-0: 2022-07-20 15:34:16 INFO juju.worker.uniter.operation ran "install" hook (via hook dispatching script: dispatch)
+unit-trfk-0: 2022-07-20 15:34:16 INFO juju.worker.uniter found queued "leader-elected" hook
+unit-trfk-0: 2022-07-20 15:34:17 INFO juju.worker.uniter.operation ran "leader-elected" hook (via hook dispatching script: dispatch)
+unit-trfk-0: 2022-07-20 15:34:18 INFO juju.worker.uniter.operation ran "configurations-storage-attached" hook (via hook dispatching script: dispatch)
+unit-trfk-0: 2022-07-20 15:34:19 INFO juju.worker.uniter.operation ran "config-changed" hook (via hook dispatching script: dispatch)
+unit-trfk-0: 2022-07-20 15:34:19 INFO juju.worker.uniter found queued "start" hook
+unit-trfk-0: 2022-07-20 15:34:19 INFO unit.trfk/0.juju-log Running legacy hooks/start.
+unit-trfk-0: 2022-07-20 15:34:20 INFO juju.worker.uniter.operation ran "start" hook (via hook dispatching script: dispatch)
+unit-trfk-0: 2022-07-20 15:34:31 INFO juju.worker.uniter.operation ran "traefik-pebble-ready" hook (via hook dispatching script: dispatch)
+unit-trfk-0: 2022-07-20 15:38:22 INFO juju.worker.uniter.operation ran "update-status" hook (via hook dispatching script: dispatch)
+unit-trfk-0: 2022-07-20 15:44:09 INFO juju.worker.uniter.operation ran "update-status" hook (via hook dispatching script: dispatch)
+unit-trfk-0: 2022-07-20 15:48:05 INFO juju.worker.uniter.operation ran "update-status" hook (via hook dispatching script: dispatch)
+unit-trfk-0: 2022-07-20 15:48:10 INFO juju.worker.uniter.operation ran "update-status" hook (via hook dispatching script: dispatch)

--- a/jhack/tests/utils/tail_mocks/real-trfk-log-with-date.txt
+++ b/jhack/tests/utils/tail_mocks/real-trfk-log-with-date.txt
@@ -1,0 +1,295 @@
+unit-trfk-0: 2022-05-01 10:07:59 INFO juju.cmd running containerAgent [2.9.31 93e5d53b99a0fc4e5294972a6c3bd3950defc0d1 gc go1.18.2]
+unit-trfk-0: 2022-05-01 10:07:59 INFO juju.cmd.containeragent.unit start "unit"
+unit-trfk-0: 2022-05-01 10:07:59 INFO juju.worker.upgradesteps upgrade steps for 2.9.31 have already been run.
+unit-trfk-0: 2022-05-01 10:07:59 INFO juju.worker.probehttpserver starting http server on [::]:3856
+unit-trfk-0: 2022-05-01 10:07:59 INFO juju.api cannot resolve "controller-service.controller-mk8scloud.svc.cluster.local": lookup controller-service.controller-mk8scloud.svc.cluster.local: operation was canceled
+unit-trfk-0: 2022-05-01 10:07:59 INFO juju.api connection established to "wss://10.152.183.200:17070/model/ed37fe1b-b8fb-4306-8083-80760ea45e0e/api"
+unit-trfk-0: 2022-05-01 10:07:59 INFO juju.worker.apicaller [ed37fe] "unit-trfk-0" successfully connected to "10.152.183.200:17070"
+unit-trfk-0: 2022-05-01 10:07:59 INFO juju.api cannot resolve "controller-service.controller-mk8scloud.svc.cluster.local": lookup controller-service.controller-mk8scloud.svc.cluster.local: operation was canceled
+unit-trfk-0: 2022-05-01 10:07:59 INFO juju.api connection established to "wss://10.152.183.200:17070/model/ed37fe1b-b8fb-4306-8083-80760ea45e0e/api"
+unit-trfk-0: 2022-05-01 10:07:59 INFO juju.worker.apicaller [ed37fe] "unit-trfk-0" successfully connected to "10.152.183.200:17070"
+unit-trfk-0: 2022-05-01 10:07:59 INFO juju.worker.migrationminion migration phase is now: NONE
+unit-trfk-0: 2022-05-01 10:07:59 INFO juju.worker.logger logger worker started
+unit-trfk-0: 2022-05-01 10:07:59 WARNING juju.worker.proxyupdater unable to set snap core settings [proxy.http= proxy.https= proxy.store=]: exec: "snap": executable file not found in $PATH, output: ""
+unit-trfk-0: 2022-05-01 10:08:00 DEBUG unit.trfk/0.juju-log Operator Framework 1.3.0 up and running.
+unit-trfk-0: 2022-05-01 10:08:00 INFO unit.trfk/0.juju-log Running legacy hooks/install.
+unit-trfk-0: 2022-05-01 10:08:00 DEBUG unit.trfk/0.juju-log Operator Framework 1.3.0 up and running.
+unit-trfk-0: 2022-05-01 10:08:00 DEBUG unit.trfk/0.juju-log Charm called itself via hooks/install.
+unit-trfk-0: 2022-05-01 10:08:01 DEBUG unit.trfk/0.juju-log Legacy hooks/install exited with status 0.
+unit-trfk-0: 2022-05-01 10:08:01 DEBUG unit.trfk/0.juju-log yaml does not have libyaml extensions, using slower pure Python yaml loader
+unit-trfk-0: 2022-05-01 10:08:01 DEBUG unit.trfk/0.juju-log Using local storage: not a kubernetes charm
+unit-trfk-0: 2022-05-01 10:08:01 DEBUG unit.trfk/0.juju-log Emitting Juju event install.
+unit-trfk-0: 2022-05-01 10:08:01 DEBUG unit.trfk/0.juju-log HTTP Request: PATCH https://10.152.183.1/api/v1/namespaces/foo/services/trfk "HTTP/1.1 200 OK"
+unit-trfk-0: 2022-05-01 10:08:01 INFO unit.trfk/0.juju-log Kubernetes service 'trfk' patched successfully
+unit-trfk-0: 2022-05-01 10:08:01 DEBUG unit.trfk/0.juju-log Operator Framework 1.3.0 up and running.
+unit-trfk-0: 2022-05-01 10:08:01 DEBUG unit.trfk/0.juju-log Legacy hooks/leader-elected does not exist.
+unit-trfk-0: 2022-05-01 10:08:01 DEBUG unit.trfk/0.juju-log yaml does not have libyaml extensions, using slower pure Python yaml loader
+unit-trfk-0: 2022-05-01 10:08:01 DEBUG unit.trfk/0.juju-log Using local storage: /var/lib/juju/agents/unit-trfk-0/charm/.unit-state.db already exists
+unit-trfk-0: 2022-05-01 10:08:01 DEBUG unit.trfk/0.juju-log Emitting Juju event leader_elected.
+unit-trfk-0: 2022-05-01 10:08:02 DEBUG unit.trfk/0.juju-log Operator Framework 1.3.0 up and running.
+unit-trfk-0: 2022-05-01 10:08:02 DEBUG unit.trfk/0.juju-log Legacy hooks/configurations-storage-attached does not exist.
+unit-trfk-0: 2022-05-01 10:08:02 DEBUG unit.trfk/0.juju-log yaml does not have libyaml extensions, using slower pure Python yaml loader
+unit-trfk-0: 2022-05-01 10:08:02 DEBUG unit.trfk/0.juju-log Using local storage: /var/lib/juju/agents/unit-trfk-0/charm/.unit-state.db already exists
+unit-trfk-0: 2022-05-01 10:08:02 DEBUG unit.trfk/0.juju-log Emitting Juju event configurations_storage_attached.
+unit-trfk-0: 2022-05-01 10:08:02 DEBUG unit.trfk/0.juju-log Operator Framework 1.3.0 up and running.
+unit-trfk-0: 2022-05-01 10:08:02 DEBUG unit.trfk/0.juju-log Legacy hooks/config-changed does not exist.
+unit-trfk-0: 2022-05-01 10:08:02 DEBUG unit.trfk/0.juju-log yaml does not have libyaml extensions, using slower pure Python yaml loader
+unit-trfk-0: 2022-05-01 10:08:02 DEBUG unit.trfk/0.juju-log Using local storage: /var/lib/juju/agents/unit-trfk-0/charm/.unit-state.db already exists
+unit-trfk-0: 2022-05-01 10:08:02 DEBUG unit.trfk/0.juju-log Emitting Juju event config_changed.
+unit-trfk-0: 2022-05-01 10:08:02 DEBUG unit.trfk/0.juju-log HTTP Request: GET https://10.152.183.1/api/v1/namespaces/foo/services/trfk "HTTP/1.1 200 OK"
+unit-trfk-0: 2022-05-01 10:08:02 DEBUG unit.trfk/0.juju-log HTTP Request: GET https://10.152.183.1/api/v1/namespaces/foo/services/trfk "HTTP/1.1 200 OK"
+unit-trfk-0: 2022-05-01 10:08:03 DEBUG unit.trfk/0.juju-log Operator Framework 1.3.0 up and running.
+unit-trfk-0: 2022-05-01 10:08:03 INFO unit.trfk/0.juju-log Running legacy hooks/start.
+unit-trfk-0: 2022-05-01 10:08:03 DEBUG unit.trfk/0.juju-log Operator Framework 1.3.0 up and running.
+unit-trfk-0: 2022-05-01 10:08:03 DEBUG unit.trfk/0.juju-log Charm called itself via hooks/start.
+unit-trfk-0: 2022-05-01 10:08:03 DEBUG unit.trfk/0.juju-log Legacy hooks/start exited with status 0.
+unit-trfk-0: 2022-05-01 10:08:03 DEBUG unit.trfk/0.juju-log yaml does not have libyaml extensions, using slower pure Python yaml loader
+unit-trfk-0: 2022-05-01 10:08:03 DEBUG unit.trfk/0.juju-log Using local storage: /var/lib/juju/agents/unit-trfk-0/charm/.unit-state.db already exists
+unit-trfk-0: 2022-05-01 10:08:03 DEBUG unit.trfk/0.juju-log Emitting Juju event start.
+unit-trfk-0: 2022-05-01 10:08:03 DEBUG unit.trfk/0.juju-log HTTP Request: GET https://10.152.183.1/api/v1/namespaces/foo/services/trfk "HTTP/1.1 200 OK"
+unit-trfk-0: 2022-05-01 10:08:04 DEBUG unit.trfk/0.juju-log Operator Framework 1.3.0 up and running.
+unit-trfk-0: 2022-05-01 10:08:04 DEBUG unit.trfk/0.juju-log Legacy hooks/traefik-pebble-ready does not exist.
+unit-trfk-0: 2022-05-01 10:08:04 DEBUG unit.trfk/0.juju-log yaml does not have libyaml extensions, using slower pure Python yaml loader
+unit-trfk-0: 2022-05-01 10:08:04 DEBUG unit.trfk/0.juju-log Using local storage: /var/lib/juju/agents/unit-trfk-0/charm/.unit-state.db already exists
+unit-trfk-0: 2022-05-01 10:08:04 DEBUG unit.trfk/0.juju-log Emitting Juju event traefik_pebble_ready.
+unit-trfk-0: 2022-05-01 10:08:05 DEBUG unit.trfk/0.juju-log HTTP Request: GET https://10.152.183.1/api/v1/namespaces/foo/services/trfk "HTTP/1.1 200 OK"
+unit-trfk-0: 2022-05-01 10:09:57 DEBUG unit.trfk/0.juju-log Operator Framework 1.3.0 up and running.
+unit-trfk-0: 2022-05-01 10:09:57 DEBUG unit.trfk/0.juju-log Legacy hooks/stop does not exist.
+unit-trfk-0: 2022-05-01 10:09:57 DEBUG unit.trfk/0.juju-log yaml does not have libyaml extensions, using slower pure Python yaml loader
+unit-trfk-0: 2022-05-01 10:09:57 DEBUG unit.trfk/0.juju-log Using local storage: /var/lib/juju/agents/unit-trfk-0/charm/.unit-state.db already exists
+unit-trfk-0: 2022-05-01 10:09:57 DEBUG unit.trfk/0.juju-log Emitting Juju event stop.
+unit-trfk-0: 2022-05-01 10:10:00 INFO juju.cmd running containerAgent [2.9.31 93e5d53b99a0fc4e5294972a6c3bd3950defc0d1 gc go1.18.2]
+unit-trfk-0: 2022-05-01 10:10:00 INFO juju.cmd.containeragent.unit start "unit"
+unit-trfk-0: 2022-05-01 10:10:00 INFO juju.worker.upgradesteps upgrade steps for 2.9.31 have already been run.
+unit-trfk-0: 2022-05-01 10:10:00 INFO juju.worker.probehttpserver starting http server on [::]:3856
+unit-trfk-0: 2022-05-01 10:10:00 INFO juju.api cannot resolve "controller-service.controller-mk8scloud.svc.cluster.local": lookup controller-service.controller-mk8scloud.svc.cluster.local: operation was canceled
+unit-trfk-0: 2022-05-01 10:10:00 INFO juju.api connection established to "wss://10.152.183.200:17070/model/ed37fe1b-b8fb-4306-8083-80760ea45e0e/api"
+unit-trfk-0: 2022-05-01 10:10:00 INFO juju.worker.apicaller [ed37fe] "unit-trfk-0" successfully connected to "10.152.183.200:17070"
+unit-trfk-0: 2022-05-01 10:10:00 INFO juju.worker.migrationminion migration phase is now: NONE
+unit-trfk-0: 2022-05-01 10:10:00 INFO juju.worker.logger logger worker started
+unit-trfk-0: 2022-05-01 10:10:00 INFO juju.worker.leadership trfk/0 promoted to leadership of trfk
+unit-trfk-0: 2022-05-01 10:10:00 WARNING juju.worker.proxyupdater unable to set snap core settings [proxy.http= proxy.https= proxy.store=]: exec: "snap": executable file not found in $PATH, output: ""
+unit-trfk-0: 2022-05-01 10:10:02 DEBUG unit.trfk/0.juju-log Operator Framework 1.3.0 up and running.
+unit-trfk-0: 2022-05-01 10:10:02 INFO unit.trfk/0.juju-log Running legacy hooks/upgrade-charm.
+unit-trfk-0: 2022-05-01 10:10:02 DEBUG unit.trfk/0.juju-log Operator Framework 1.3.0 up and running.
+unit-trfk-0: 2022-05-01 10:10:02 DEBUG unit.trfk/0.juju-log Charm called itself via hooks/upgrade-charm.
+unit-trfk-0: 2022-05-01 10:10:02 DEBUG unit.trfk/0.juju-log Legacy hooks/upgrade-charm exited with status 0.
+unit-trfk-0: 2022-05-01 10:10:02 DEBUG unit.trfk/0.juju-log yaml does not have libyaml extensions, using slower pure Python yaml loader
+unit-trfk-0: 2022-05-01 10:10:02 DEBUG unit.trfk/0.juju-log Using local storage: not a kubernetes charm
+unit-trfk-0: 2022-05-01 10:10:02 DEBUG unit.trfk/0.juju-log Emitting Juju event upgrade_charm.
+unit-trfk-0: 2022-05-01 10:10:02 DEBUG unit.trfk/0.juju-log HTTP Request: PATCH https://10.152.183.1/api/v1/namespaces/foo/services/trfk "HTTP/1.1 200 OK"
+unit-trfk-0: 2022-05-01 10:10:02 INFO unit.trfk/0.juju-log Kubernetes service 'trfk' patched successfully
+unit-trfk-0: 2022-05-01 10:10:02 DEBUG unit.trfk/0.juju-log Reading alert rule from /var/lib/juju/agents/unit-trfk-0/charm/src/prometheus_alert_rules/unit_unavailable.rule
+unit-trfk-0: 2022-05-01 10:10:02 DEBUG unit.trfk/0.juju-log Operator Framework 1.3.0 up and running.
+unit-trfk-0: 2022-05-01 10:10:02 DEBUG unit.trfk/0.juju-log Legacy hooks/config-changed does not exist.
+unit-trfk-0: 2022-05-01 10:10:02 DEBUG unit.trfk/0.juju-log yaml does not have libyaml extensions, using slower pure Python yaml loader
+unit-trfk-0: 2022-05-01 10:10:02 DEBUG unit.trfk/0.juju-log Using local storage: /var/lib/juju/agents/unit-trfk-0/charm/.unit-state.db already exists
+unit-trfk-0: 2022-05-01 10:10:02 DEBUG unit.trfk/0.juju-log Emitting Juju event config_changed.
+unit-trfk-0: 2022-05-01 10:10:02 DEBUG unit.trfk/0.juju-log HTTP Request: GET https://10.152.183.1/api/v1/namespaces/foo/services/trfk "HTTP/1.1 200 OK"
+unit-trfk-0: 2022-05-01 10:10:02 DEBUG unit.trfk/0.juju-log HTTP Request: GET https://10.152.183.1/api/v1/namespaces/foo/services/trfk "HTTP/1.1 200 OK"
+unit-trfk-0: 2022-05-01 10:10:03 DEBUG unit.trfk/0.juju-log Operator Framework 1.3.0 up and running.
+unit-trfk-0: 2022-05-01 10:10:03 INFO unit.trfk/0.juju-log Running legacy hooks/start.
+unit-trfk-0: 2022-05-01 10:10:03 DEBUG unit.trfk/0.juju-log Operator Framework 1.3.0 up and running.
+unit-trfk-0: 2022-05-01 10:10:03 DEBUG unit.trfk/0.juju-log Charm called itself via hooks/start.
+unit-trfk-0: 2022-05-01 10:10:03 DEBUG unit.trfk/0.juju-log Legacy hooks/start exited with status 0.
+unit-trfk-0: 2022-05-01 10:10:03 DEBUG unit.trfk/0.juju-log yaml does not have libyaml extensions, using slower pure Python yaml loader
+unit-trfk-0: 2022-05-01 10:10:03 DEBUG unit.trfk/0.juju-log Using local storage: /var/lib/juju/agents/unit-trfk-0/charm/.unit-state.db already exists
+unit-trfk-0: 2022-05-01 10:10:03 DEBUG unit.trfk/0.juju-log Emitting Juju event start.
+unit-trfk-0: 2022-05-01 10:10:03 DEBUG unit.trfk/0.juju-log HTTP Request: GET https://10.152.183.1/api/v1/namespaces/foo/services/trfk "HTTP/1.1 200 OK"
+unit-trfk-0: 2022-05-01 10:10:05 DEBUG unit.trfk/0.juju-log Operator Framework 1.3.0 up and running.
+unit-trfk-0: 2022-05-01 10:10:05 DEBUG unit.trfk/0.juju-log Legacy hooks/traefik-pebble-ready does not exist.
+unit-trfk-0: 2022-05-01 10:10:05 DEBUG unit.trfk/0.juju-log yaml does not have libyaml extensions, using slower pure Python yaml loader
+unit-trfk-0: 2022-05-01 10:10:05 DEBUG unit.trfk/0.juju-log Using local storage: /var/lib/juju/agents/unit-trfk-0/charm/.unit-state.db already exists
+unit-trfk-0: 2022-05-01 10:10:05 DEBUG unit.trfk/0.juju-log Emitting Juju event traefik_pebble_ready.
+unit-trfk-0: 2022-05-01 10:10:06 DEBUG unit.trfk/0.juju-log HTTP Request: GET https://10.152.183.1/api/v1/namespaces/foo/services/trfk "HTTP/1.1 200 OK"
+unit-trfk-0: 2022-05-01 10:11:54 DEBUG unit.trfk/0.juju-log Operator Framework 1.3.0 up and running.
+unit-trfk-0: 2022-05-01 10:11:54 DEBUG unit.trfk/0.juju-log Legacy hooks/update-status does not exist.
+unit-trfk-0: 2022-05-01 10:11:54 DEBUG unit.trfk/0.juju-log yaml does not have libyaml extensions, using slower pure Python yaml loader
+unit-trfk-0: 2022-05-01 10:11:54 DEBUG unit.trfk/0.juju-log Using local storage: /var/lib/juju/agents/unit-trfk-0/charm/.unit-state.db already exists
+unit-trfk-0: 2022-05-01 10:11:54 DEBUG unit.trfk/0.juju-log Emitting Juju event update_status.
+unit-trfk-0: 2022-05-01 10:11:54 DEBUG unit.trfk/0.juju-log HTTP Request: GET https://10.152.183.1/api/v1/namespaces/foo/services/trfk "HTTP/1.1 200 OK"
+unit-trfk-0: 2022-05-01 10:11:59 DEBUG unit.trfk/0.juju-log Operator Framework 1.3.0 up and running.
+unit-trfk-0: 2022-05-01 10:11:59 DEBUG unit.trfk/0.juju-log Legacy hooks/update-status does not exist.
+unit-trfk-0: 2022-05-01 10:11:59 DEBUG unit.trfk/0.juju-log yaml does not have libyaml extensions, using slower pure Python yaml loader
+unit-trfk-0: 2022-05-01 10:11:59 DEBUG unit.trfk/0.juju-log Using local storage: /var/lib/juju/agents/unit-trfk-0/charm/.unit-state.db already exists
+unit-trfk-0: 2022-05-01 10:11:59 DEBUG unit.trfk/0.juju-log Emitting Juju event update_status.
+unit-trfk-0: 2022-05-01 10:11:59 DEBUG unit.trfk/0.juju-log HTTP Request: GET https://10.152.183.1/api/v1/namespaces/foo/services/trfk "HTTP/1.1 200 OK"
+unit-trfk-0: 2022-05-01 10:11:59 DEBUG unit.trfk/0.juju-log Deferring <UpdateStatusEvent via TraefikIngressCharm/on/update_status[16]>.
+unit-trfk-0: 2022-05-01 10:12:04 DEBUG unit.trfk/0.juju-log Operator Framework 1.3.0 up and running.
+unit-trfk-0: 2022-05-01 10:12:04 DEBUG unit.trfk/0.juju-log Legacy hooks/update-status does not exist.
+unit-trfk-0: 2022-05-01 10:12:04 DEBUG unit.trfk/0.juju-log yaml does not have libyaml extensions, using slower pure Python yaml loader
+unit-trfk-0: 2022-05-01 10:12:04 DEBUG unit.trfk/0.juju-log Using local storage: /var/lib/juju/agents/unit-trfk-0/charm/.unit-state.db already exists
+unit-trfk-0: 2022-05-01 10:12:04 DEBUG unit.trfk/0.juju-log Re-emitting <UpdateStatusEvent via TraefikIngressCharm/on/update_status[16]>.
+unit-trfk-0: 2022-05-01 10:12:04 DEBUG unit.trfk/0.juju-log HTTP Request: GET https://10.152.183.1/api/v1/namespaces/foo/services/trfk "HTTP/1.1 200 OK"
+unit-trfk-0: 2022-05-01 10:12:04 DEBUG unit.trfk/0.juju-log Deferring <UpdateStatusEvent via TraefikIngressCharm/on/update_status[16]>.
+unit-trfk-0: 2022-05-01 10:12:04 DEBUG unit.trfk/0.juju-log Emitting Juju event update_status.
+unit-trfk-0: 2022-05-01 10:12:04 DEBUG unit.trfk/0.juju-log HTTP Request: GET https://10.152.183.1/api/v1/namespaces/foo/services/trfk "HTTP/1.1 200 OK"
+unit-trfk-0: 2022-05-01 10:12:09 DEBUG unit.trfk/0.juju-log Operator Framework 1.3.0 up and running.
+unit-trfk-0: 2022-05-01 10:12:09 DEBUG unit.trfk/0.juju-log Legacy hooks/update-status does not exist.
+unit-trfk-0: 2022-05-01 10:12:09 DEBUG unit.trfk/0.juju-log yaml does not have libyaml extensions, using slower pure Python yaml loader
+unit-trfk-0: 2022-05-01 10:12:09 DEBUG unit.trfk/0.juju-log Using local storage: /var/lib/juju/agents/unit-trfk-0/charm/.unit-state.db already exists
+unit-trfk-0: 2022-05-01 10:12:09 DEBUG unit.trfk/0.juju-log Re-emitting <UpdateStatusEvent via TraefikIngressCharm/on/update_status[16]>.
+unit-trfk-0: 2022-05-01 10:12:09 DEBUG unit.trfk/0.juju-log HTTP Request: GET https://10.152.183.1/api/v1/namespaces/foo/services/trfk "HTTP/1.1 200 OK"
+unit-trfk-0: 2022-05-01 10:12:09 DEBUG unit.trfk/0.juju-log Emitting Juju event update_status.
+unit-trfk-0: 2022-05-01 10:12:09 DEBUG unit.trfk/0.juju-log HTTP Request: GET https://10.152.183.1/api/v1/namespaces/foo/services/trfk "HTTP/1.1 200 OK"
+unit-trfk-0: 2022-05-01 10:12:14 DEBUG unit.trfk/0.juju-log Operator Framework 1.3.0 up and running.
+unit-trfk-0: 2022-05-01 10:12:14 DEBUG unit.trfk/0.juju-log Legacy hooks/update-status does not exist.
+unit-trfk-0: 2022-05-01 10:12:14 DEBUG unit.trfk/0.juju-log yaml does not have libyaml extensions, using slower pure Python yaml loader
+unit-trfk-0: 2022-05-01 10:12:14 DEBUG unit.trfk/0.juju-log Using local storage: /var/lib/juju/agents/unit-trfk-0/charm/.unit-state.db already exists
+unit-trfk-0: 2022-05-01 10:12:14 DEBUG unit.trfk/0.juju-log Emitting Juju event update_status.
+unit-trfk-0: 2022-05-01 10:12:14 DEBUG unit.trfk/0.juju-log HTTP Request: GET https://10.152.183.1/api/v1/namespaces/foo/services/trfk "HTTP/1.1 200 OK"
+unit-trfk-0: 2022-05-01 10:12:14 DEBUG unit.trfk/0.juju-log Deferring <UpdateStatusEvent via TraefikIngressCharm/on/update_status[25]>.
+unit-trfk-0: 2022-05-01 10:12:19 DEBUG unit.trfk/0.juju-log Operator Framework 1.3.0 up and running.
+unit-trfk-0: 2022-05-01 10:12:19 DEBUG unit.trfk/0.juju-log Legacy hooks/update-status does not exist.
+unit-trfk-0: 2022-05-01 10:12:19 DEBUG unit.trfk/0.juju-log yaml does not have libyaml extensions, using slower pure Python yaml loader
+unit-trfk-0: 2022-05-01 10:12:19 DEBUG unit.trfk/0.juju-log Using local storage: /var/lib/juju/agents/unit-trfk-0/charm/.unit-state.db already exists
+unit-trfk-0: 2022-05-01 10:12:19 DEBUG unit.trfk/0.juju-log Re-emitting <UpdateStatusEvent via TraefikIngressCharm/on/update_status[25]>.
+unit-trfk-0: 2022-05-01 10:12:19 DEBUG unit.trfk/0.juju-log HTTP Request: GET https://10.152.183.1/api/v1/namespaces/foo/services/trfk "HTTP/1.1 200 OK"
+unit-trfk-0: 2022-05-01 10:12:19 DEBUG unit.trfk/0.juju-log Emitting Juju event update_status.
+unit-trfk-0: 2022-05-01 10:12:19 DEBUG unit.trfk/0.juju-log HTTP Request: GET https://10.152.183.1/api/v1/namespaces/foo/services/trfk "HTTP/1.1 200 OK"
+unit-trfk-0: 2022-05-01 10:12:19 DEBUG unit.trfk/0.juju-log Deferring <UpdateStatusEvent via TraefikIngressCharm/on/update_status[28]>.
+unit-trfk-0: 2022-05-01 10:12:24 DEBUG unit.trfk/0.juju-log Operator Framework 1.3.0 up and running.
+unit-trfk-0: 2022-05-01 10:12:24 DEBUG unit.trfk/0.juju-log Legacy hooks/update-status does not exist.
+unit-trfk-0: 2022-05-01 10:12:24 DEBUG unit.trfk/0.juju-log yaml does not have libyaml extensions, using slower pure Python yaml loader
+unit-trfk-0: 2022-05-01 10:12:24 DEBUG unit.trfk/0.juju-log Using local storage: /var/lib/juju/agents/unit-trfk-0/charm/.unit-state.db already exists
+unit-trfk-0: 2022-05-01 10:12:24 DEBUG unit.trfk/0.juju-log Re-emitting <UpdateStatusEvent via TraefikIngressCharm/on/update_status[28]>.
+unit-trfk-0: 2022-05-01 10:12:24 DEBUG unit.trfk/0.juju-log HTTP Request: GET https://10.152.183.1/api/v1/namespaces/foo/services/trfk "HTTP/1.1 200 OK"
+unit-trfk-0: 2022-05-01 10:12:24 DEBUG unit.trfk/0.juju-log Emitting Juju event update_status.
+unit-trfk-0: 2022-05-01 10:12:24 DEBUG unit.trfk/0.juju-log HTTP Request: GET https://10.152.183.1/api/v1/namespaces/foo/services/trfk "HTTP/1.1 200 OK"
+unit-trfk-0: 2022-05-01 10:12:28 DEBUG unit.trfk/0.juju-log Operator Framework 1.3.0 up and running.
+unit-trfk-0: 2022-05-01 10:12:28 DEBUG unit.trfk/0.juju-log Legacy hooks/update-status does not exist.
+unit-trfk-0: 2022-05-01 10:12:28 DEBUG unit.trfk/0.juju-log yaml does not have libyaml extensions, using slower pure Python yaml loader
+unit-trfk-0: 2022-05-01 10:12:29 DEBUG unit.trfk/0.juju-log Using local storage: /var/lib/juju/agents/unit-trfk-0/charm/.unit-state.db already exists
+unit-trfk-0: 2022-05-01 10:12:29 DEBUG unit.trfk/0.juju-log Emitting Juju event update_status.
+unit-trfk-0: 2022-05-01 10:12:29 DEBUG unit.trfk/0.juju-log HTTP Request: GET https://10.152.183.1/api/v1/namespaces/foo/services/trfk "HTTP/1.1 200 OK"
+unit-trfk-0: 2022-05-01 10:12:29 DEBUG unit.trfk/0.juju-log Deferring <UpdateStatusEvent via TraefikIngressCharm/on/update_status[34]>.
+unit-trfk-0: 2022-05-01 10:12:30 DEBUG unit.trfk/0.juju-log Operator Framework 1.3.0 up and running.
+unit-trfk-0: 2022-05-01 10:12:30 DEBUG unit.trfk/0.juju-log Legacy hooks/config-changed does not exist.
+unit-trfk-0: 2022-05-01 10:12:30 DEBUG unit.trfk/0.juju-log yaml does not have libyaml extensions, using slower pure Python yaml loader
+unit-trfk-0: 2022-05-01 10:12:30 DEBUG unit.trfk/0.juju-log Using local storage: /var/lib/juju/agents/unit-trfk-0/charm/.unit-state.db already exists
+unit-trfk-0: 2022-05-01 10:12:30 DEBUG unit.trfk/0.juju-log Re-emitting <UpdateStatusEvent via TraefikIngressCharm/on/update_status[34]>.
+unit-trfk-0: 2022-05-01 10:12:30 DEBUG unit.trfk/0.juju-log Emitting Juju event config_changed.
+unit-trfk-0: 2022-05-01 10:12:34 DEBUG unit.trfk/0.juju-log Operator Framework 1.3.0 up and running.
+unit-trfk-0: 2022-05-01 10:12:34 DEBUG unit.trfk/0.juju-log Legacy hooks/update-status does not exist.
+unit-trfk-0: 2022-05-01 10:12:34 DEBUG unit.trfk/0.juju-log yaml does not have libyaml extensions, using slower pure Python yaml loader
+unit-trfk-0: 2022-05-01 10:12:34 DEBUG unit.trfk/0.juju-log Using local storage: /var/lib/juju/agents/unit-trfk-0/charm/.unit-state.db already exists
+unit-trfk-0: 2022-05-01 10:12:34 DEBUG unit.trfk/0.juju-log Emitting Juju event update_status.
+unit-trfk-0: 2022-05-01 10:12:34 DEBUG unit.trfk/0.juju-log Deferring <UpdateStatusEvent via TraefikIngressCharm/on/update_status[40]>.
+unit-trfk-0: 2022-05-01 10:12:39 DEBUG unit.trfk/0.juju-log Operator Framework 1.3.0 up and running.
+unit-trfk-0: 2022-05-01 10:12:39 DEBUG unit.trfk/0.juju-log Legacy hooks/update-status does not exist.
+unit-trfk-0: 2022-05-01 10:12:39 DEBUG unit.trfk/0.juju-log yaml does not have libyaml extensions, using slower pure Python yaml loader
+unit-trfk-0: 2022-05-01 10:12:39 DEBUG unit.trfk/0.juju-log Using local storage: /var/lib/juju/agents/unit-trfk-0/charm/.unit-state.db already exists
+unit-trfk-0: 2022-05-01 10:12:39 DEBUG unit.trfk/0.juju-log Re-emitting <UpdateStatusEvent via TraefikIngressCharm/on/update_status[40]>.
+unit-trfk-0: 2022-05-01 10:12:39 DEBUG unit.trfk/0.juju-log Deferring <UpdateStatusEvent via TraefikIngressCharm/on/update_status[40]>.
+unit-trfk-0: 2022-05-01 10:12:39 DEBUG unit.trfk/0.juju-log Emitting Juju event update_status.
+unit-trfk-0: 2022-05-01 10:12:44 DEBUG unit.trfk/0.juju-log Operator Framework 1.3.0 up and running.
+unit-trfk-0: 2022-05-01 10:12:44 DEBUG unit.trfk/0.juju-log Legacy hooks/update-status does not exist.
+unit-trfk-0: 2022-05-01 10:12:44 DEBUG unit.trfk/0.juju-log yaml does not have libyaml extensions, using slower pure Python yaml loader
+unit-trfk-0: 2022-05-01 10:12:44 DEBUG unit.trfk/0.juju-log Using local storage: /var/lib/juju/agents/unit-trfk-0/charm/.unit-state.db already exists
+unit-trfk-0: 2022-05-01 10:12:44 DEBUG unit.trfk/0.juju-log Re-emitting <UpdateStatusEvent via TraefikIngressCharm/on/update_status[40]>.
+unit-trfk-0: 2022-05-01 10:12:44 DEBUG unit.trfk/0.juju-log Deferring <UpdateStatusEvent via TraefikIngressCharm/on/update_status[40]>.
+unit-trfk-0: 2022-05-01 10:12:44 DEBUG unit.trfk/0.juju-log Emitting Juju event update_status.
+unit-trfk-0: 2022-05-01 10:18:06 DEBUG unit.trfk/0.juju-log Operator Framework 1.3.0 up and running.
+unit-trfk-0: 2022-05-01 10:18:06 DEBUG unit.trfk/0.juju-log Legacy hooks/update-status does not exist.
+unit-trfk-0: 2022-05-01 10:18:06 DEBUG unit.trfk/0.juju-log yaml does not have libyaml extensions, using slower pure Python yaml loader
+unit-trfk-0: 2022-05-01 10:18:06 DEBUG unit.trfk/0.juju-log Using local storage: /var/lib/juju/agents/unit-trfk-0/charm/.unit-state.db already exists
+unit-trfk-0: 2022-05-01 10:18:06 DEBUG unit.trfk/0.juju-log Re-emitting <UpdateStatusEvent via TraefikIngressCharm/on/update_status[40]>.
+unit-trfk-0: 2022-05-01 10:18:06 DEBUG unit.trfk/0.juju-log Deferring <UpdateStatusEvent via TraefikIngressCharm/on/update_status[40]>.
+unit-trfk-0: 2022-05-01 10:18:06 DEBUG unit.trfk/0.juju-log Emitting Juju event update_status.
+unit-trfk-0: 2022-05-01 10:23:38 DEBUG unit.trfk/0.juju-log Operator Framework 1.3.0 up and running.
+unit-trfk-0: 2022-05-01 10:23:38 DEBUG unit.trfk/0.juju-log Legacy hooks/update-status does not exist.
+unit-trfk-0: 2022-05-01 10:23:38 DEBUG unit.trfk/0.juju-log yaml does not have libyaml extensions, using slower pure Python yaml loader
+unit-trfk-0: 2022-05-01 10:23:38 DEBUG unit.trfk/0.juju-log Using local storage: /var/lib/juju/agents/unit-trfk-0/charm/.unit-state.db already exists
+unit-trfk-0: 2022-05-01 10:23:38 DEBUG unit.trfk/0.juju-log Re-emitting <UpdateStatusEvent via TraefikIngressCharm/on/update_status[40]>.
+unit-trfk-0: 2022-05-01 10:23:38 DEBUG unit.trfk/0.juju-log Deferring <UpdateStatusEvent via TraefikIngressCharm/on/update_status[40]>.
+unit-trfk-0: 2022-05-01 10:23:38 DEBUG unit.trfk/0.juju-log Emitting Juju event update_status.
+unit-trfk-0: 2022-05-01 10:23:38 DEBUG unit.trfk/0.juju-log Deferring <UpdateStatusEvent via TraefikIngressCharm/on/update_status[52]>.
+unit-trfk-0: 2022-05-01 10:28:35 DEBUG unit.trfk/0.juju-log Operator Framework 1.3.0 up and running.
+unit-trfk-0: 2022-05-01 10:28:35 DEBUG unit.trfk/0.juju-log Legacy hooks/update-status does not exist.
+unit-trfk-0: 2022-05-01 10:28:35 DEBUG unit.trfk/0.juju-log yaml does not have libyaml extensions, using slower pure Python yaml loader
+unit-trfk-0: 2022-05-01 10:28:35 DEBUG unit.trfk/0.juju-log Using local storage: /var/lib/juju/agents/unit-trfk-0/charm/.unit-state.db already exists
+unit-trfk-0: 2022-05-01 10:28:35 DEBUG unit.trfk/0.juju-log Re-emitting <UpdateStatusEvent via TraefikIngressCharm/on/update_status[40]>.
+unit-trfk-0: 2022-05-01 10:28:35 DEBUG unit.trfk/0.juju-log Deferring <UpdateStatusEvent via TraefikIngressCharm/on/update_status[40]>.
+unit-trfk-0: 2022-05-01 10:28:35 DEBUG unit.trfk/0.juju-log Re-emitting <UpdateStatusEvent via TraefikIngressCharm/on/update_status[52]>.
+unit-trfk-0: 2022-05-01 10:28:36 DEBUG unit.trfk/0.juju-log Emitting Juju event update_status.
+unit-trfk-0: 2022-05-01 10:28:36 DEBUG unit.trfk/0.juju-log Deferring <UpdateStatusEvent via TraefikIngressCharm/on/update_status[55]>.
+unit-trfk-0: 2022-05-01 10:33:53 DEBUG unit.trfk/0.juju-log Operator Framework 1.3.0 up and running.
+unit-trfk-0: 2022-05-01 10:33:53 DEBUG unit.trfk/0.juju-log Legacy hooks/update-status does not exist.
+unit-trfk-0: 2022-05-01 10:33:53 DEBUG unit.trfk/0.juju-log yaml does not have libyaml extensions, using slower pure Python yaml loader
+unit-trfk-0: 2022-05-01 10:33:53 DEBUG unit.trfk/0.juju-log Using local storage: /var/lib/juju/agents/unit-trfk-0/charm/.unit-state.db already exists
+unit-trfk-0: 2022-05-01 10:33:53 DEBUG unit.trfk/0.juju-log Re-emitting <UpdateStatusEvent via TraefikIngressCharm/on/update_status[40]>.
+unit-trfk-0: 2022-05-01 10:33:53 DEBUG unit.trfk/0.juju-log Deferring <UpdateStatusEvent via TraefikIngressCharm/on/update_status[40]>.
+unit-trfk-0: 2022-05-01 10:33:53 DEBUG unit.trfk/0.juju-log Re-emitting <UpdateStatusEvent via TraefikIngressCharm/on/update_status[55]>.
+unit-trfk-0: 2022-05-01 10:33:53 DEBUG unit.trfk/0.juju-log Emitting Juju event update_status.
+unit-trfk-0: 2022-05-01 10:39:35 DEBUG unit.trfk/0.juju-log Operator Framework 1.3.0 up and running.
+unit-trfk-0: 2022-05-01 10:39:35 DEBUG unit.trfk/0.juju-log Legacy hooks/update-status does not exist.
+unit-trfk-0: 2022-05-01 10:39:35 DEBUG unit.trfk/0.juju-log yaml does not have libyaml extensions, using slower pure Python yaml loader
+unit-trfk-0: 2022-05-01 10:39:35 DEBUG unit.trfk/0.juju-log Using local storage: /var/lib/juju/agents/unit-trfk-0/charm/.unit-state.db already exists
+unit-trfk-0: 2022-05-01 10:39:35 DEBUG unit.trfk/0.juju-log Re-emitting <UpdateStatusEvent via TraefikIngressCharm/on/update_status[40]>.
+unit-trfk-0: 2022-05-01 10:39:36 DEBUG unit.trfk/0.juju-log Emitting Juju event update_status.
+unit-trfk-0: 2022-05-01 10:44:15 DEBUG unit.trfk/0.juju-log Operator Framework 1.3.0 up and running.
+unit-trfk-0: 2022-05-01 10:44:15 DEBUG unit.trfk/0.juju-log Legacy hooks/update-status does not exist.
+unit-trfk-0: 2022-05-01 10:44:15 DEBUG unit.trfk/0.juju-log yaml does not have libyaml extensions, using slower pure Python yaml loader
+unit-trfk-0: 2022-05-01 10:44:15 DEBUG unit.trfk/0.juju-log Using local storage: /var/lib/juju/agents/unit-trfk-0/charm/.unit-state.db already exists
+unit-trfk-0: 2022-05-01 10:44:15 DEBUG unit.trfk/0.juju-log Emitting Juju event update_status.
+unit-trfk-0: 2022-05-01 10:44:15 DEBUG unit.trfk/0.juju-log Deferring <UpdateStatusEvent via TraefikIngressCharm/on/update_status[64]>.
+unit-trfk-0: 2022-05-01 10:49:30 DEBUG unit.trfk/0.juju-log Operator Framework 1.3.0 up and running.
+unit-trfk-0: 2022-05-01 10:49:30 DEBUG unit.trfk/0.juju-log Legacy hooks/update-status does not exist.
+unit-trfk-0: 2022-05-01 10:49:30 DEBUG unit.trfk/0.juju-log yaml does not have libyaml extensions, using slower pure Python yaml loader
+unit-trfk-0: 2022-05-01 10:49:30 DEBUG unit.trfk/0.juju-log Using local storage: /var/lib/juju/agents/unit-trfk-0/charm/.unit-state.db already exists
+unit-trfk-0: 2022-05-01 10:49:30 DEBUG unit.trfk/0.juju-log Re-emitting <UpdateStatusEvent via TraefikIngressCharm/on/update_status[64]>.
+unit-trfk-0: 2022-05-01 10:49:30 DEBUG unit.trfk/0.juju-log Emitting Juju event update_status.
+unit-trfk-0: 2022-05-01 10:54:18 DEBUG unit.trfk/0.juju-log Operator Framework 1.3.0 up and running.
+unit-trfk-0: 2022-05-01 10:54:18 DEBUG unit.trfk/0.juju-log Legacy hooks/update-status does not exist.
+unit-trfk-0: 2022-05-01 10:54:18 DEBUG unit.trfk/0.juju-log yaml does not have libyaml extensions, using slower pure Python yaml loader
+unit-trfk-0: 2022-05-01 10:54:18 DEBUG unit.trfk/0.juju-log Using local storage: /var/lib/juju/agents/unit-trfk-0/charm/.unit-state.db already exists
+unit-trfk-0: 2022-05-01 10:54:18 DEBUG unit.trfk/0.juju-log Emitting Juju event update_status.
+unit-trfk-0: 2022-05-01 10:54:18 DEBUG unit.trfk/0.juju-log Deferring <UpdateStatusEvent via TraefikIngressCharm/on/update_status[70]>.
+unit-trfk-0: 2022-05-01 10:59:14 DEBUG unit.trfk/0.juju-log Operator Framework 1.3.0 up and running.
+unit-trfk-0: 2022-05-01 10:59:14 DEBUG unit.trfk/0.juju-log Legacy hooks/update-status does not exist.
+unit-trfk-0: 2022-05-01 10:59:14 DEBUG unit.trfk/0.juju-log yaml does not have libyaml extensions, using slower pure Python yaml loader
+unit-trfk-0: 2022-05-01 10:59:14 DEBUG unit.trfk/0.juju-log Using local storage: /var/lib/juju/agents/unit-trfk-0/charm/.unit-state.db already exists
+unit-trfk-0: 2022-05-01 10:59:14 DEBUG unit.trfk/0.juju-log Re-emitting <UpdateStatusEvent via TraefikIngressCharm/on/update_status[70]>.
+unit-trfk-0: 2022-05-01 10:59:14 DEBUG unit.trfk/0.juju-log Emitting Juju event update_status.
+unit-trfk-0: 2022-05-01 10:59:14 DEBUG unit.trfk/0.juju-log Deferring <UpdateStatusEvent via TraefikIngressCharm/on/update_status[73]>.
+unit-trfk-0: 2022-05-01 11:04:30 DEBUG unit.trfk/0.juju-log Operator Framework 1.3.0 up and running.
+unit-trfk-0: 2022-05-01 11:04:30 DEBUG unit.trfk/0.juju-log Legacy hooks/update-status does not exist.
+unit-trfk-0: 2022-05-01 11:04:30 DEBUG unit.trfk/0.juju-log yaml does not have libyaml extensions, using slower pure Python yaml loader
+unit-trfk-0: 2022-05-01 11:04:30 DEBUG unit.trfk/0.juju-log Using local storage: /var/lib/juju/agents/unit-trfk-0/charm/.unit-state.db already exists
+unit-trfk-0: 2022-05-01 11:04:30 DEBUG unit.trfk/0.juju-log Re-emitting <UpdateStatusEvent via TraefikIngressCharm/on/update_status[73]>.
+unit-trfk-0: 2022-05-01 11:04:30 DEBUG unit.trfk/0.juju-log Deferring <UpdateStatusEvent via TraefikIngressCharm/on/update_status[73]>.
+unit-trfk-0: 2022-05-01 11:04:30 DEBUG unit.trfk/0.juju-log Emitting Juju event update_status.
+unit-trfk-0: 2022-05-01 11:04:30 DEBUG unit.trfk/0.juju-log Deferring <UpdateStatusEvent via TraefikIngressCharm/on/update_status[76]>.
+unit-trfk-0: 2022-05-01 11:09:18 DEBUG unit.trfk/0.juju-log Operator Framework 1.3.0 up and running.
+unit-trfk-0: 2022-05-01 11:09:18 DEBUG unit.trfk/0.juju-log Legacy hooks/update-status does not exist.
+unit-trfk-0: 2022-05-01 11:09:18 DEBUG unit.trfk/0.juju-log yaml does not have libyaml extensions, using slower pure Python yaml loader
+unit-trfk-0: 2022-05-01 11:09:18 DEBUG unit.trfk/0.juju-log Using local storage: /var/lib/juju/agents/unit-trfk-0/charm/.unit-state.db already exists
+unit-trfk-0: 2022-05-01 11:09:18 DEBUG unit.trfk/0.juju-log Re-emitting <UpdateStatusEvent via TraefikIngressCharm/on/update_status[73]>.
+unit-trfk-0: 2022-05-01 11:09:18 DEBUG unit.trfk/0.juju-log Re-emitting <UpdateStatusEvent via TraefikIngressCharm/on/update_status[76]>.
+unit-trfk-0: 2022-05-01 11:09:18 DEBUG unit.trfk/0.juju-log Deferring <UpdateStatusEvent via TraefikIngressCharm/on/update_status[76]>.
+unit-trfk-0: 2022-05-01 11:09:18 DEBUG unit.trfk/0.juju-log Emitting Juju event update_status.
+unit-trfk-0: 2022-05-01 11:09:18 DEBUG unit.trfk/0.juju-log Deferring <UpdateStatusEvent via TraefikIngressCharm/on/update_status[79]>.
+unit-trfk-0: 2022-05-01 11:13:52 DEBUG unit.trfk/0.juju-log Operator Framework 1.3.0 up and running.
+unit-trfk-0: 2022-05-01 11:13:52 DEBUG unit.trfk/0.juju-log Legacy hooks/update-status does not exist.
+unit-trfk-0: 2022-05-01 11:13:52 DEBUG unit.trfk/0.juju-log yaml does not have libyaml extensions, using slower pure Python yaml loader
+unit-trfk-0: 2022-05-01 11:13:52 DEBUG unit.trfk/0.juju-log Using local storage: /var/lib/juju/agents/unit-trfk-0/charm/.unit-state.db already exists
+unit-trfk-0: 2022-05-01 11:13:52 DEBUG unit.trfk/0.juju-log Re-emitting <UpdateStatusEvent via TraefikIngressCharm/on/update_status[76]>.
+unit-trfk-0: 2022-05-01 11:13:53 DEBUG unit.trfk/0.juju-log Deferring <UpdateStatusEvent via TraefikIngressCharm/on/update_status[76]>.
+unit-trfk-0: 2022-05-01 11:13:53 DEBUG unit.trfk/0.juju-log Re-emitting <UpdateStatusEvent via TraefikIngressCharm/on/update_status[79]>.
+unit-trfk-0: 2022-05-01 11:13:53 DEBUG unit.trfk/0.juju-log Deferring <UpdateStatusEvent via TraefikIngressCharm/on/update_status[79]>.
+unit-trfk-0: 2022-05-01 11:13:53 DEBUG unit.trfk/0.juju-log Emitting Juju event update_status.
+unit-trfk-0: 2022-05-01 11:18:20 DEBUG unit.trfk/0.juju-log Operator Framework 1.3.0 up and running.
+unit-trfk-0: 2022-05-01 11:18:20 DEBUG unit.trfk/0.juju-log Legacy hooks/update-status does not exist.
+unit-trfk-0: 2022-05-01 11:18:20 DEBUG unit.trfk/0.juju-log yaml does not have libyaml extensions, using slower pure Python yaml loader
+unit-trfk-0: 2022-05-01 11:18:20 DEBUG unit.trfk/0.juju-log Using local storage: /var/lib/juju/agents/unit-trfk-0/charm/.unit-state.db already exists
+unit-trfk-0: 2022-05-01 11:18:20 DEBUG unit.trfk/0.juju-log Re-emitting <UpdateStatusEvent via TraefikIngressCharm/on/update_status[76]>.
+unit-trfk-0: 2022-05-01 11:18:20 DEBUG unit.trfk/0.juju-log Re-emitting <UpdateStatusEvent via TraefikIngressCharm/on/update_status[79]>.
+unit-trfk-0: 2022-05-01 11:18:20 DEBUG unit.trfk/0.juju-log Emitting Juju event update_status.
+unit-trfk-0: 2022-05-01 11:23:18 DEBUG unit.trfk/0.juju-log Operator Framework 1.3.0 up and running.
+unit-trfk-0: 2022-05-01 11:23:18 DEBUG unit.trfk/0.juju-log Legacy hooks/update-status does not exist.
+unit-trfk-0: 2022-05-01 11:23:18 DEBUG unit.trfk/0.juju-log yaml does not have libyaml extensions, using slower pure Python yaml loader
+unit-trfk-0: 2022-05-01 11:23:18 DEBUG unit.trfk/0.juju-log Using local storage: /var/lib/juju/agents/unit-trfk-0/charm/.unit-state.db already exists
+unit-trfk-0: 2022-05-01 11:23:18 DEBUG unit.trfk/0.juju-log Emitting Juju event update_status.
+unit-trfk-0: 2022-05-01 11:23:18 DEBUG unit.trfk/0.juju-log Deferring <UpdateStatusEvent via TraefikIngressCharm/on/update_status[88]>.
+unit-trfk-0: 2022-05-01 11:28:55 DEBUG unit.trfk/0.juju-log Operator Framework 1.3.0 up and running.
+unit-trfk-0: 2022-05-01 11:28:55 DEBUG unit.trfk/0.juju-log Legacy hooks/update-status does not exist.

--- a/jhack/tests/utils/test_debug_file_interlace.py
+++ b/jhack/tests/utils/test_debug_file_interlace.py
@@ -1,0 +1,47 @@
+from contextlib import nullcontext
+
+import pytest
+from _pytest.python_api import RaisesContext  # Not sure if there's a better way for this
+from jhack.utils.debug_log_interlacer import DebugLogInterlacer
+
+
+@pytest.mark.parametrize(
+    'input_files, expected_output_file, context_raised',
+    (
+            (
+                    ["./tail_mocks/interlace-log-0.txt"],
+                    "./tail_mocks/interlace-log-0.txt",
+                    nullcontext(),
+            ),
+            (
+                    ["./tail_mocks/interlace-log-0.txt", "./tail_mocks/interlace-log-1.txt"],
+                    "./tail_mocks/interlace-log-combined.txt",
+                    nullcontext(),
+            ),
+            (
+                    ["./tail_mocks/interlace-log-no-date.txt", "./tail_mocks/interlace-log-1.txt"],
+                    None,
+                    pytest.raises(ValueError),
+            ),
+    ),
+)
+def test_debug_file_interlace_read(input_files, expected_output_file, context_raised):
+
+    dli = DebugLogInterlacer(input_files)
+
+    lines = []
+    with context_raised:
+        while True:
+            this_line = dli.readline()
+            if this_line:
+                lines.append(this_line)
+            else:
+                break
+
+    if not isinstance(context_raised, RaisesContext):
+        # If we didn't raise, then assert the output is correct
+        with open(expected_output_file, 'r') as fin:
+            expected_lines = fin.readlines()
+
+        assert lines == expected_lines
+

--- a/jhack/tests/utils/test_debug_file_interlace.py
+++ b/jhack/tests/utils/test_debug_file_interlace.py
@@ -1,36 +1,32 @@
-from contextlib import nullcontext
-
 import pytest
-from _pytest.python_api import RaisesContext  # Not sure if there's a better way for this
 from jhack.utils.debug_log_interlacer import DebugLogInterlacer
 
 
 @pytest.mark.parametrize(
-    'input_files, expected_output_file, context_raised',
+    'input_files, expected_output_file',
     (
             (
                     ["./tail_mocks/interlace-log-0.txt"],
                     "./tail_mocks/interlace-log-0.txt",
-                    nullcontext(),
             ),
             (
                     ["./tail_mocks/interlace-log-0.txt", "./tail_mocks/interlace-log-1.txt"],
                     "./tail_mocks/interlace-log-combined.txt",
-                    nullcontext(),
             ),
             (
-                    ["./tail_mocks/interlace-log-no-date.txt", "./tail_mocks/interlace-log-1.txt"],
+                    ["./tail_mocks/interlace-log-no-date.txt",
+                     "./tail_mocks/interlace-log-1.txt"],
                     None,
-                    pytest.raises(ValueError),
             ),
     ),
 )
-def test_debug_file_interlace_read(input_files, expected_output_file, context_raised):
+def test_debug_file_interlace_read(input_files, expected_output_file):
 
     dli = DebugLogInterlacer(input_files)
 
     lines = []
-    with context_raised:
+
+    def read_all():
         while True:
             this_line = dli.readline()
             if this_line:
@@ -38,7 +34,13 @@ def test_debug_file_interlace_read(input_files, expected_output_file, context_ra
             else:
                 break
 
-    if not isinstance(context_raised, RaisesContext):
+    if not expected_output_file:
+        with pytest.raises(ValueError):
+            read_all()
+    else:
+        read_all()
+
+    if expected_output_file is not None:
         # If we didn't raise, then assert the output is correct
         with open(expected_output_file, 'r') as fin:
             expected_lines = fin.readlines()

--- a/jhack/tests/utils/test_tail.py
+++ b/jhack/tests/utils/test_tail.py
@@ -177,5 +177,7 @@ def test_tracking_reemit_only():
 
 
 def test_tail_with_file_input():
-    _tail_events(files=["./tail_mocks/interlace-log-0.txt", "./tail_mocks/interlace-log-1.txt"])
+    _tail_events(
+        files=["./tail_mocks/real-prom-cropped-for-interlace.txt", "./tail_mocks/real-trfk-cropped-for-interlace.txt"]
+    )
 

--- a/jhack/tests/utils/test_tail.py
+++ b/jhack/tests/utils/test_tail.py
@@ -174,3 +174,8 @@ def test_tracking_reemit_only():
     assert raw_table.ns == ['0', '0']
     assert raw_table.events == ['update_status', 'update_status']
     assert len(raw_table.currently_deferred) == 0
+
+
+def test_tail_with_file_input():
+    _tail_events(files=["./tail_mocks/interlace-log-0.txt", "./tail_mocks/interlace-log-1.txt"])
+

--- a/jhack/tests/utils/test_tail.py
+++ b/jhack/tests/utils/test_tail.py
@@ -52,12 +52,13 @@ MOCK_JDL = {
         """,
 }
 
-with open(Path(__file__).parent / 'tail_mocks' / 'real-trfk-log.txt',
+mocks_dir = Path(__file__).parent / 'tail_mocks'
+with open(mocks_dir / 'real-trfk-log.txt',
           mode='rb') as f:
     logs = f.read()
     MOCK_JDL['real'] = logs
 
-with open(Path(__file__).parent / 'tail_mocks' / 'real-trfk-cropped.txt',
+with open(mocks_dir / 'real-trfk-cropped.txt',
           mode='rb') as f:
     logs = f.read()
     MOCK_JDL['cropped'] = logs
@@ -178,6 +179,7 @@ def test_tracking_reemit_only():
 
 def test_tail_with_file_input():
     _tail_events(
-        files=["./tail_mocks/real-prom-cropped-for-interlace.txt", "./tail_mocks/real-trfk-cropped-for-interlace.txt"]
+        files=["./tail_mocks/real-prom-cropped-for-interlace.txt",
+               "./tail_mocks/real-trfk-cropped-for-interlace.txt"]
     )
 

--- a/jhack/utils/debug_log_interlacer.py
+++ b/jhack/utils/debug_log_interlacer.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+from typing import Union, List
+
+from jhack.utils.file_peeker import FilePeeker
+import parse
+
+
+class DebugLogInterlacer:
+    """Helper to interlace debug-logs
+
+    Yields the chronologically next row across one or more debug log files, keeping track of
+    progress so that successive calls to readline will progress through the monitored files.
+
+    # TODO: Cleanup file peekers and their pointers?
+    """
+    line_pattern = parse.compile("{_}: {timestamp:ti} {_}")
+    line_pattern_no_date = parse.compile("{_}: {timestamp:tt} {_}")
+    def __init__(self, files: List[Union[Path, str]]):
+        self.files = [Path(f) for f in files]
+        self.file_peekers = [FilePeeker(f) for f in self.files]
+
+    def readline(self):
+        """Returns the chronologically next line from the collection log files"""
+        next_line_timestamp = None
+        next_line_file_index = None
+
+        for i, file_peeker in enumerate(self.file_peekers):
+            try:
+                line = file_peeker.peekline()
+
+                # Skip blank lines
+                if line.strip() == "":
+                    continue
+
+                if match := self.line_pattern.parse(line):
+                    this_timestamp = match.named["timestamp"]
+                    if next_line_timestamp is None or this_timestamp < next_line_timestamp:
+                        next_line_timestamp = this_timestamp
+                        next_line_file_index = i
+                else:
+                    if self.line_pattern_no_date.parse(line):
+                        raise ValueError(
+                            f"Could not parse line from file {file_peeker.filename}, no full "
+                            f"datetime found.  Did you export with `juju debug-log --date`?"
+                        )
+                    else:
+                        raise ValueError(
+                            f"Cannot parse line {line} from file {file_peeker.filename} for "
+                            f"unknown reasons."
+                        )
+            except StopIteration:
+                continue
+
+        if next_line_file_index is not None:
+            return self.file_peekers[next_line_file_index].readline()
+        else:
+            return ''

--- a/jhack/utils/debug_log_interlacer.py
+++ b/jhack/utils/debug_log_interlacer.py
@@ -1,5 +1,3 @@
-import datetime
-from itertools import chain
 from pathlib import Path
 from typing import Union, List
 
@@ -12,8 +10,6 @@ class DebugLogInterlacer:
 
     Yields the chronologically next row across one or more debug log files, keeping track of
     progress so that successive calls to readline will progress through the monitored files.
-
-    # TODO: Cleanup file peekers and their pointers?
     """
     line_pattern = parse.compile("{_}: {timestamp:ti} {_}")
     line_pattern_no_date = parse.compile("{_}: {timestamp:tt} {_}")
@@ -58,48 +54,3 @@ class DebugLogInterlacer:
             return self.file_peekers[next_line_file_index].readline()
         else:
             return ''
-
-
-# class DebugLogSequencer:
-#     """Helper to sequence debug-logs
-#
-#     Yields the rows of a bunch of files, sorted by the first timestamp we
-#     can find in them.
-#
-#     """
-#     line_pattern = parse.compile("{_}: {timestamp:ti} {_}")
-#     line_pattern_no_date = parse.compile("{_}: {timestamp:tt} {_}")
-#
-#     def __init__(self, files: List[Union[Path, str]]):
-#         self.files = [Path(f) for f in files]
-#         sorted_files = sorted(files, key=self.by_timestamp)
-#
-#         from jhack.utils.tail_charms import logger
-#         logger.debug(f"files sorted by timestamp: {sorted_files}")
-#         peekers = map(FilePeeker, sorted_files)
-#         self._line_iterator = iter(chain(*peekers))
-#
-#     def by_timestamp(self, file: Path):
-#         with open(file, 'r') as f:
-#             first_line = f.readline()
-#         match = self.line_pattern.parse(first_line)
-#         if match and (tstamp := match.named.get('timestamp')):
-#             timestamp: datetime.datetime = tstamp
-#             return tstamp
-#         elif time := self.line_pattern_no_date.parse(first_line):
-#             timestamp: datetime.time = time.named.get('timestamp')
-#             dt = datetime.datetime.now().replace(hour=timestamp.hour,
-#                                                  minute=timestamp.minute,
-#                                                  second=timestamp.second)  # assume it's today
-#             return dt
-#         raise ValueError(
-#             f'first line of {file} matches no known pattern;'
-#             f'{first_line[:20]!r}. Is this a juju debug-log line?'
-#         )
-#
-#     def readline(self):
-#         """Returns the chronologically next line from the collection log files"""
-#         try:
-#             return next(self._line_iterator)
-#         except StopIteration:  # conform to file.readline() behaviour
-#             return ""

--- a/jhack/utils/debug_log_interlacer.py
+++ b/jhack/utils/debug_log_interlacer.py
@@ -1,3 +1,5 @@
+import datetime
+from itertools import chain
 from pathlib import Path
 from typing import Union, List
 
@@ -15,6 +17,7 @@ class DebugLogInterlacer:
     """
     line_pattern = parse.compile("{_}: {timestamp:ti} {_}")
     line_pattern_no_date = parse.compile("{_}: {timestamp:tt} {_}")
+
     def __init__(self, files: List[Union[Path, str]]):
         self.files = [Path(f) for f in files]
         self.file_peekers = [FilePeeker(f) for f in self.files]
@@ -55,3 +58,48 @@ class DebugLogInterlacer:
             return self.file_peekers[next_line_file_index].readline()
         else:
             return ''
+
+
+# class DebugLogSequencer:
+#     """Helper to sequence debug-logs
+#
+#     Yields the rows of a bunch of files, sorted by the first timestamp we
+#     can find in them.
+#
+#     """
+#     line_pattern = parse.compile("{_}: {timestamp:ti} {_}")
+#     line_pattern_no_date = parse.compile("{_}: {timestamp:tt} {_}")
+#
+#     def __init__(self, files: List[Union[Path, str]]):
+#         self.files = [Path(f) for f in files]
+#         sorted_files = sorted(files, key=self.by_timestamp)
+#
+#         from jhack.utils.tail_charms import logger
+#         logger.debug(f"files sorted by timestamp: {sorted_files}")
+#         peekers = map(FilePeeker, sorted_files)
+#         self._line_iterator = iter(chain(*peekers))
+#
+#     def by_timestamp(self, file: Path):
+#         with open(file, 'r') as f:
+#             first_line = f.readline()
+#         match = self.line_pattern.parse(first_line)
+#         if match and (tstamp := match.named.get('timestamp')):
+#             timestamp: datetime.datetime = tstamp
+#             return tstamp
+#         elif time := self.line_pattern_no_date.parse(first_line):
+#             timestamp: datetime.time = time.named.get('timestamp')
+#             dt = datetime.datetime.now().replace(hour=timestamp.hour,
+#                                                  minute=timestamp.minute,
+#                                                  second=timestamp.second)  # assume it's today
+#             return dt
+#         raise ValueError(
+#             f'first line of {file} matches no known pattern;'
+#             f'{first_line[:20]!r}. Is this a juju debug-log line?'
+#         )
+#
+#     def readline(self):
+#         """Returns the chronologically next line from the collection log files"""
+#         try:
+#             return next(self._line_iterator)
+#         except StopIteration:  # conform to file.readline() behaviour
+#             return ""

--- a/jhack/utils/file_peeker.py
+++ b/jhack/utils/file_peeker.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+from typing import Union, AnyStr, List
+
+
+class FilePeeker:
+    """A wrapper around a file object that allows you to peek ahead in the file
+
+    To interact with the base file object, use the .file attribute
+    """
+    # TODO: Add enter and exit to make cleanup easier
+    def __init__(self, filename: Union[str, Path]):
+        self.filename = str(filename)
+        self.file = open(self.filename, "r")
+
+    def peekline(self) -> AnyStr:
+        """Peek at the next line of the file without moving the file pointer."""
+        return self.peeklines(n_lines=1)[0]
+
+    def peeklines(self, n_lines: int) -> List[AnyStr]:
+        """Peek at the next n_lines of the file without moving the file pointer.
+
+        Inspired by: https://stackoverflow.com/a/16840747/5394584
+        """
+        original_position = self.file.tell()
+        lines = [self.file.readline() for _ in range(n_lines)]
+        self.file.seek(original_position)
+        return lines
+
+    def read(self, *args, **kwargs):
+        """Convenience alias to access underlying file object's read method"""
+        return self.file.read(*args, **kwargs)
+
+    def readline(self, *args, **kwargs):
+        """Convenience alias to access underlying file object's read method"""
+        return self.file.readline(*args, **kwargs)
+
+    def readlines(self, *args, **kwargs):
+        """Convenience alias to access underlying file object's readlines method"""
+        return self.file.readlines(*args, **kwargs)

--- a/jhack/utils/file_peeker.py
+++ b/jhack/utils/file_peeker.py
@@ -37,3 +37,11 @@ class FilePeeker:
     def readlines(self, *args, **kwargs):
         """Convenience alias to access underlying file object's readlines method"""
         return self.file.readlines(*args, **kwargs)
+
+    def __iter__(self):
+        while True:
+            line = self.readline()
+            if not line:
+                return
+            yield line
+

--- a/jhack/utils/tail_charms.py
+++ b/jhack/utils/tail_charms.py
@@ -1,6 +1,7 @@
 import enum
 import os
 import random
+import re
 import sys
 import time
 from collections import defaultdict, Counter
@@ -190,8 +191,7 @@ class Processor:
                  history_length: int = 10,
                  show_ns: bool = True,
                  color: bool = True,
-                 show_defer: bool = False,
-                 date: bool = False):
+                 show_defer: bool = False):
         if not color:
             # maybe implement it some day.
             logger.debug('Sorry, but colors are too pretty to get rid of.')
@@ -219,40 +219,23 @@ class Processor:
 
         self._warned_about_orphans = False
 
-        if date:
-            self.event = parse.compile(
-                "{pod_name}: {date} {timestamp} {loglevel} unit.{unit}.juju-log Emitting Juju event {event}.")
-            self.event_from_relation = parse.compile(
-                "{pod_name}: {date} {timestamp} {loglevel} unit.{unit}.juju-log {endpoint}:{endpoint_id}: Emitting Juju event {event}.")
-            self.uniter_event = parse.compile(
-                '{pod_name}: {date} {timestamp} {loglevel} juju.worker.uniter.operation ran "{event}" hook (via hook dispatching script: dispatch)')
-            self.event_deferred = parse.compile(
-                '{pod_name}: {date} {timestamp} {loglevel} unit.{unit}.juju-log Deferring <{event_cls} via {charm_name}/on/{event}[{n}]>.')
-            self.event_deferred_from_relation = parse.compile(
-                '{pod_name}: {date} {timestamp} {loglevel} unit.{unit}.juju-log {endpoint}:{endpoint_id}: Deferring <{event_cls} via {charm_name}/on/{event}[{n}]>.')
-            self.event_reemitted = parse.compile(
-                '{pod_name}: {date} {timestamp} {loglevel} unit.{unit}.juju-log Re-emitting <{event_cls} via {charm_name}/on/{event}[{n}]>.'
-            )
-            self.event_reemitted_from_relation = parse.compile(
-                '{pod_name}: {date} {timestamp} {loglevel} unit.{unit}.juju-log {endpoint}:{endpoint_id}: Re-emitting <{event_cls} via {charm_name}/on/{event}[{n}]>.'
-            )
-        else:
-            self.event = parse.compile(
-                "{pod_name}: {timestamp} {loglevel} unit.{unit}.juju-log Emitting Juju event {event}.")
-            self.event_from_relation = parse.compile(
-                "{pod_name}: {timestamp} {loglevel} unit.{unit}.juju-log {endpoint}:{endpoint_id}: Emitting Juju event {event}.")
-            self.uniter_event = parse.compile(
-                '{pod_name}: {timestamp} {loglevel} juju.worker.uniter.operation ran "{event}" hook (via hook dispatching script: dispatch)')
-            self.event_deferred = parse.compile(
-                '{pod_name}: {timestamp} {loglevel} unit.{unit}.juju-log Deferring <{event_cls} via {charm_name}/on/{event}[{n}]>.')
-            self.event_deferred_from_relation = parse.compile(
-                '{pod_name}: {timestamp} {loglevel} unit.{unit}.juju-log {endpoint}:{endpoint_id}: Deferring <{event_cls} via {charm_name}/on/{event}[{n}]>.')
-            self.event_reemitted = parse.compile(
-                '{pod_name}: {timestamp} {loglevel} unit.{unit}.juju-log Re-emitting <{event_cls} via {charm_name}/on/{event}[{n}]>.'
-            )
-            self.event_reemitted_from_relation = parse.compile(
-                '{pod_name}: {timestamp} {loglevel} unit.{unit}.juju-log {endpoint}:{endpoint_id}: Re-emitting <{event_cls} via {charm_name}/on/{event}[{n}]>.'
-            )
+        base_pattern = "^(?P<pod_name>\S+): (?P<timestamp>\S+(\s*\S+)?) (?P<loglevel>\S+) unit\.(?P<unit>\S+)\.juju-log "
+        base_relation_pattern = base_pattern + "(?P<endpoint>\S+):(?P<endpoint_id>\S+): "
+
+        event_suffix = "Emitting Juju event (?P<event>\S+)\."
+        self.event = re.compile(base_pattern + event_suffix)
+        self.event_from_relation = re.compile(base_relation_pattern + event_suffix)
+
+        self.uniter_event = re.compile('^(?P<pod_name>\S+): (?P<timestamp>\S+( \S+)?) (?P<loglevel>\S+) juju\.worker\.uniter\.operation ran \"(?P<event>\S+)\" hook \(via hook dispatching script: dispatch\)')
+
+        event_repr = "<(?P<event_cls>\S+) via (?P<charm_name>\S+)/on/(?P<event>\S+)\[(?P<n>\d+)\]>\."
+        defer_suffix = "Deferring " + event_repr
+        self.event_deferred = re.compile(base_pattern + defer_suffix)
+        self.event_deferred_from_relation = re.compile(base_relation_pattern + defer_suffix)
+
+        reemitted_suffix = "Re-emitting " + event_repr
+        self.event_reemitted = re.compile(base_pattern + reemitted_suffix)
+        self.event_reemitted_from_relation = re.compile(base_relation_pattern + reemitted_suffix)
 
     def _warn_about_orphaned_event(self, evt):
         if self._warned_about_orphans:
@@ -361,10 +344,10 @@ class Processor:
     def _match_event_deferred(self, log: str) -> Optional[EventDeferredLogMsg]:
         if "Deferring" not in log:
             return
-        match = self.event_deferred.parse(
-            log) or self.event_deferred_from_relation.parse(log)
+        match = self.event_deferred.match(
+            log) or self.event_deferred_from_relation.match(log)
         if match:
-            params = match.named
+            params = match.groupdict()
             params['event'] = self._uniform_event(params['event'])
             return EventDeferredLogMsg(**params, mocked=False)
 
@@ -372,10 +355,10 @@ class Processor:
         EventReemittedLogMsg]:
         if "Re-emitting" not in log:
             return
-        match = self.event_reemitted.parse(
-            log) or self.event_reemitted_from_relation.parse(log)
+        match = self.event_reemitted.match(
+            log) or self.event_reemitted_from_relation.match(log)
         if match:
-            params = match.named
+            params = match.groupdict()
             params['event'] = self._uniform_event(params['event'])
             return EventReemittedLogMsg(**params, mocked=False)
 
@@ -384,20 +367,13 @@ class Processor:
         # unit-traefik-k8s-0: 10:36:19 DEBUG unit.traefik-k8s/0.juju-log ingress-per-unit:38: Emitting Juju event ingress_per_unit_relation_changed.
         # unit-prometheus-k8s-0: 13:06:09 DEBUG unit.prometheus-k8s/0.juju-log ingress:44: Emitting Juju event ingress_relation_changed.
 
-        match = self.event.parse(log)
-
-        # search for relation events
-        if not match:
-            match = self.event_from_relation.parse(log)
-            if match:
-                params = match.named
-
+        match = self.event.match(log) or self.event_from_relation.match(log)
         # attempt to match in another format ?
         if not match:
             # fallback
-            if match := self.uniter_event.parse(log):
-                unit = parse.compile("unit-{}").parse(match.named['pod_name'])
-                params = match.named
+            if match := self.uniter_event.match(log):
+                params = match.groupdict()
+                unit = parse.compile("unit-{}").parse(params['pod_name'])
                 *names, number = unit.fixed[0].split('-')
                 name = '-'.join(names)
                 params['unit'] = '/'.join([name, number])
@@ -405,7 +381,7 @@ class Processor:
                 return
 
         else:
-            params = match.named
+            params = match.groupdict()
 
         # uniform
         params['event'] = params['event'].replace('-', '_')
@@ -947,13 +923,6 @@ def _tail_events(
         logger.debug(f"ignoring `watch` because files were provided")
         watch = False
 
-    if files:
-        # If we're using file input, they must also have dates in the output
-        date = True
-    else:
-        date = False
-
-
     logger.debug('starting to read logs')
     cmd = ([JUJU_COMMAND, 'debug-log'] +
            (['--tail'] if watch else []) +
@@ -969,9 +938,9 @@ def _tail_events(
         history_length=length,
         show_ns=show_ns,
         color=color,
-        show_defer=show_defer,
-        date=date
+        show_defer=show_defer
     )
+
     try:
         # when we're in replay mode we're catching up with the replayed logs
         # so we won't limit the framerate and just flush the output
@@ -1035,6 +1004,8 @@ def _tail_events(
     finally:
         processor.quit()
 
+    return processor  # for testing
+
 
 def _put(s: str, index: int, char: Union[str, Dict[str, str]], placeholder=' '):
     if isinstance(char, str):
@@ -1050,4 +1021,4 @@ def _put(s: str, index: int, char: Union[str, Dict[str, str]], placeholder=' '):
 
 
 if __name__ == '__main__':
-    _tail_events(replay=True, show_defer=True, show_ns=True, length=40)
+    _tail_events(files=['/home/pietro/jdl.txt'])

--- a/jhack/utils/tail_charms.py
+++ b/jhack/utils/tail_charms.py
@@ -220,7 +220,6 @@ class Processor:
         self._warned_about_orphans = False
 
         if date:
-            print("Setting patterns to use date")
             self.event = parse.compile(
                 "{pod_name}: {date} {timestamp} {loglevel} unit.{unit}.juju-log Emitting Juju event {event}.")
             self.event_from_relation = parse.compile(

--- a/jhack/utils/tail_charms.py
+++ b/jhack/utils/tail_charms.py
@@ -214,13 +214,12 @@ class Processor:
 
         self._has_just_emitted = False
         self.console = console = Console()
-        self.live = Live(console=console)
-        self.render()
+        self.live = live = Live(console=console)
+        live.start()
 
         self._warned_about_orphans = False
 
         if date:
-            print("Setting patterns to use date")
             self.event = parse.compile(
                 "{pod_name}: {date} {timestamp} {loglevel} unit.{unit}.juju-log Emitting Juju event {event}.")
             self.event_from_relation = parse.compile(
@@ -531,7 +530,9 @@ class Processor:
         self.live.update(table_centered)
 
         if not self.live.is_started:
+            logger.info('live started by render')
             self.live.start()
+
         return table_centered
 
     def _is_tracking(self, msg):
@@ -972,8 +973,6 @@ def _tail_events(
         date=date
     )
 
-    print("TEST")
-
     try:
         # when we're in replay mode we're catching up with the replayed logs
         # so we won't limit the framerate and just flush the output
@@ -1033,10 +1032,9 @@ def _tail_events(
                 time.sleep(framerate - elapsed)
 
     except KeyboardInterrupt:
+        pass  # quit
+    finally:
         processor.quit()
-        return
-
-    print(f"processed {processor.evt_count} events.")
 
 
 def _put(s: str, index: int, char: Union[str, Dict[str, str]], placeholder=' '):

--- a/jhack/utils/tail_charms.py
+++ b/jhack/utils/tail_charms.py
@@ -184,14 +184,29 @@ def _random_color():
 class Processor:
     # FIXME: why does sometime event/relation_event work, and sometimes
     #  uniter_event does? OF Version?
+    event = parse.compile(
+        "{pod_name}: {date} {timestamp} {loglevel} unit.{unit}.juju-log Emitting Juju event {event}.")
+    event_from_relation = parse.compile(
+        "{pod_name}: {date} {timestamp} {loglevel} unit.{unit}.juju-log {endpoint}:{endpoint_id}: Emitting Juju event {event}.")
+    uniter_event = parse.compile(
+        '{pod_name}: {date} {timestamp} {loglevel} juju.worker.uniter.operation ran "{event}" hook (via hook dispatching script: dispatch)')
+    event_deferred = parse.compile(
+        '{pod_name}: {date} {timestamp} {loglevel} unit.{unit}.juju-log Deferring <{event_cls} via {charm_name}/on/{event}[{n}]>.')
+    event_deferred_from_relation = parse.compile(
+        '{pod_name}: {date} {timestamp} {loglevel} unit.{unit}.juju-log {endpoint}:{endpoint_id}: Deferring <{event_cls} via {charm_name}/on/{event}[{n}]>.')
+    event_reemitted = parse.compile(
+        '{pod_name}: {date} {timestamp} {loglevel} unit.{unit}.juju-log Re-emitting <{event_cls} via {charm_name}/on/{event}[{n}]>.'
+    )
+    event_reemitted_from_relation = parse.compile(
+        '{pod_name}: {date} {timestamp} {loglevel} unit.{unit}.juju-log {endpoint}:{endpoint_id}: Re-emitting <{event_cls} via {charm_name}/on/{event}[{n}]>.'
+    )
 
     def __init__(self, targets: Iterable[Target],
                  add_new_targets: bool = True,
                  history_length: int = 10,
                  show_ns: bool = True,
                  color: bool = True,
-                 show_defer: bool = False,
-                 date: bool = False):
+                 show_defer: bool = False):
         if not color:
             # maybe implement it some day.
             logger.debug('Sorry, but colors are too pretty to get rid of.')
@@ -218,41 +233,6 @@ class Processor:
         live.start()
 
         self._warned_about_orphans = False
-
-        if date:
-            self.event = parse.compile(
-                "{pod_name}: {date} {timestamp} {loglevel} unit.{unit}.juju-log Emitting Juju event {event}.")
-            self.event_from_relation = parse.compile(
-                "{pod_name}: {date} {timestamp} {loglevel} unit.{unit}.juju-log {endpoint}:{endpoint_id}: Emitting Juju event {event}.")
-            self.uniter_event = parse.compile(
-                '{pod_name}: {date} {timestamp} {loglevel} juju.worker.uniter.operation ran "{event}" hook (via hook dispatching script: dispatch)')
-            self.event_deferred = parse.compile(
-                '{pod_name}: {date} {timestamp} {loglevel} unit.{unit}.juju-log Deferring <{event_cls} via {charm_name}/on/{event}[{n}]>.')
-            self.event_deferred_from_relation = parse.compile(
-                '{pod_name}: {date} {timestamp} {loglevel} unit.{unit}.juju-log {endpoint}:{endpoint_id}: Deferring <{event_cls} via {charm_name}/on/{event}[{n}]>.')
-            self.event_reemitted = parse.compile(
-                '{pod_name}: {date} {timestamp} {loglevel} unit.{unit}.juju-log Re-emitting <{event_cls} via {charm_name}/on/{event}[{n}]>.'
-            )
-            self.event_reemitted_from_relation = parse.compile(
-                '{pod_name}: {date} {timestamp} {loglevel} unit.{unit}.juju-log {endpoint}:{endpoint_id}: Re-emitting <{event_cls} via {charm_name}/on/{event}[{n}]>.'
-            )
-        else:
-            self.event = parse.compile(
-                "{pod_name}: {timestamp} {loglevel} unit.{unit}.juju-log Emitting Juju event {event}.")
-            self.event_from_relation = parse.compile(
-                "{pod_name}: {timestamp} {loglevel} unit.{unit}.juju-log {endpoint}:{endpoint_id}: Emitting Juju event {event}.")
-            self.uniter_event = parse.compile(
-                '{pod_name}: {timestamp} {loglevel} juju.worker.uniter.operation ran "{event}" hook (via hook dispatching script: dispatch)')
-            self.event_deferred = parse.compile(
-                '{pod_name}: {timestamp} {loglevel} unit.{unit}.juju-log Deferring <{event_cls} via {charm_name}/on/{event}[{n}]>.')
-            self.event_deferred_from_relation = parse.compile(
-                '{pod_name}: {timestamp} {loglevel} unit.{unit}.juju-log {endpoint}:{endpoint_id}: Deferring <{event_cls} via {charm_name}/on/{event}[{n}]>.')
-            self.event_reemitted = parse.compile(
-                '{pod_name}: {timestamp} {loglevel} unit.{unit}.juju-log Re-emitting <{event_cls} via {charm_name}/on/{event}[{n}]>.'
-            )
-            self.event_reemitted_from_relation = parse.compile(
-                '{pod_name}: {timestamp} {loglevel} unit.{unit}.juju-log {endpoint}:{endpoint_id}: Re-emitting <{event_cls} via {charm_name}/on/{event}[{n}]>.'
-            )
 
     def _warn_about_orphaned_event(self, evt):
         if self._warned_about_orphans:
@@ -955,7 +935,7 @@ def _tail_events(
 
 
     logger.debug('starting to read logs')
-    cmd = ([JUJU_COMMAND, 'debug-log'] +
+    cmd = ([JUJU_COMMAND, 'debug-log', '--date'] +
            (['--tail'] if watch else []) +
            (['--replay'] if replay else []) +
            ['--level', level.value])
@@ -969,9 +949,7 @@ def _tail_events(
         history_length=length,
         show_ns=show_ns,
         color=color,
-        show_defer=show_defer,
-        date=date
-    )
+        show_defer=show_defer)
 
     try:
         # when we're in replay mode we're catching up with the replayed logs


### PR DESCRIPTION
Closes #5 

This is a (currently incomplete) solution to #5.  

Challenges encountered when doing this:
* interlacing the files without just loading them all into memory took a bit of effort, but I think the `FilePeeker` and `DebugLogInterlacer` have this sorted
* to properly interlace files, we really need dates in the output.  This is available from `juju debug-log --date`, but the original `tail` was written without this arg.  Atm this is hacked in but might not be working quite right
* some of the `_tail_events` logic was written without this feature in mind, so hacking it in felt a bit..hacky.  Might be able to refactor a little to make it nicer