### PR TITLE
added regex filter for event-name in tail

### DIFF
--- a/jhack/helpers.py
+++ b/jhack/helpers.py
@@ -37,10 +37,10 @@ JPopen = partial(subprocess.Popen, env=os.environ, stdout=PIPE)
 
 
 def juju_version():
-    proc = JPopen('juju version'.split())
-    raw = proc.stdout.read().decode('utf-8').strip()
-    if '-' in raw:
-        return raw.split('-')[0]
+    proc = JPopen("juju version".split())
+    raw = proc.stdout.read().decode("utf-8").strip()
+    if "-" in raw:
+        return raw.split("-")[0]
     return raw
 
 

--- a/jhack/tests/utils/test_show_relation_machine.py
+++ b/jhack/tests/utils/test_show_relation_machine.py
@@ -69,7 +69,7 @@ def test_databag_shape_mongo():
     assert (
         content.units_data
         == {
-            0: {
+            1: {
                 "hostname": "10.1.70.128",
                 "port": "27017",
                 "type": "database",
@@ -78,4 +78,4 @@ def test_databag_shape_mongo():
         }
         != {0: {"ceilometer_database": "ceilometer"}}
     )
-    assert content.meta.leader_id == 0
+    assert content.meta.leader_id == 1

--- a/jhack/tests/utils/test_tail.py
+++ b/jhack/tests/utils/test_tail.py
@@ -11,23 +11,33 @@ jhack.utils.tail_charms.JUJU_VERSION = "2.0"
 from jhack.utils.tail_charms import Processor, Target, _tail_events
 
 
-def _mock_emit(event_name, app_name="myapp", unit_number=0,
-               event_n=0, timestamp="12:17:50", loglevel="DEBUG"):
+def _mock_emit(
+    event_name,
+    app_name="myapp",
+    unit_number=0,
+    event_n=0,
+    timestamp="12:17:50",
+    loglevel="DEBUG",
+):
     defaults = {}
     defaults.update(
         {
-            'app_name': app_name,
-            'unit_number': unit_number,
-            'event_name': event_name,
-            'event_n': event_n,
-            'timestamp': timestamp,
-            'loglevel': loglevel,
-                     })
-    emit = "unit-{app_name}-{unit_number}: {timestamp} " \
-           "DEBUG unit.{app_name}/{unit_number}.juju-log " \
-           "Emitting Juju event {event_name}."
+            "app_name": app_name,
+            "unit_number": unit_number,
+            "event_name": event_name,
+            "event_n": event_n,
+            "timestamp": timestamp,
+            "loglevel": loglevel,
+        }
+    )
+    emit = (
+        "unit-{app_name}-{unit_number}: {timestamp} "
+        "DEBUG unit.{app_name}/{unit_number}.juju-log "
+        "Emitting Juju event {event_name}."
+    )
 
     return emit.format(**defaults)
+
 
 MOCK_JDL = {
     # scenario 1: emit, defer, reemit
@@ -213,21 +223,23 @@ def test_tail_with_file_input():
     )
 
 
-@pytest.mark.parametrize('pattern, log, match', (
-        (None, _mock_emit('foo'), True),
-        ("bar", _mock_emit('foo'), False),
-        ("foo", _mock_emit('foo'), True),
-        ("(?!foo)", _mock_emit('foo'), False),
-        ("(?!foo)", _mock_emit('foob'), False),
-        ("(?!foo)", _mock_emit('boof'), True),
-))
+@pytest.mark.parametrize(
+    "pattern, log, match",
+    (
+        (None, _mock_emit("foo"), True),
+        ("bar", _mock_emit("foo"), False),
+        ("foo", _mock_emit("foo"), True),
+        ("(?!foo)", _mock_emit("foo"), False),
+        ("(?!foo)", _mock_emit("foob"), False),
+        ("(?!foo)", _mock_emit("boof"), True),
+    ),
+)
 def test_tail_event_filter(pattern, log, match):
-    proc = Processor(targets=[],
-                     event_filter_re=(re.compile(pattern) if pattern else None))
+    proc = Processor(
+        targets=[], event_filter_re=(re.compile(pattern) if pattern else None)
+    )
     msg = proc.process(log)
     if match:
         assert msg
     else:
         assert msg is None
-
-

--- a/jhack/utils/show_relation.py
+++ b/jhack/utils/show_relation.py
@@ -392,7 +392,7 @@ async def render_relation(
             n_rel = len(relations)
             plur_rel = n_rel > 1
 
-            def pl(condition, a='', b=''):
+            def pl(condition, a="", b=""):
                 """Conditional pluralizer."""
                 return condition and a or b
 


### PR DESCRIPTION
Fixes #10 

To test:
`jhack tail -f (?!update)` --> should filter out `update*` events (including `update_status`).
`jhack tail -f my_relation` --> should only include `my_relation*` events.