### PR TITLE
Fix shell syntax error during "jhack fire" with --env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ local_snap_install
 *.dbdump
 event_db.json
 .coverage
+/venv

--- a/jhack/utils/simulate_event.py
+++ b/jhack/utils/simulate_event.py
@@ -114,12 +114,12 @@ def _simulate_event(
     event,
     relation_remote: str = None,
     operator_dispatch: bool = False,
-    env_override: str = None,
+    env_override: List[str] = None,
     print_captured_stdout: bool = False,
     print_captured_stderr: bool = False,
     emit_juju_log: bool = True,
 ):
-    env = env_override or _get_env(
+    env = _get_env(
         unit,
         event,
         relation_remote=relation_remote,


### PR DESCRIPTION
```
$ jhack fire database/0 secret-rotate --env JUJU_SECRET_ID=cdu2c3js26oc760lq4h0
ERROR:jhack.simulate_event:cmd juju ssh database/0 /usr/bin/juju-exec -u database/0 ('JUJU_SECRET_ID=cdu2c3js26oc760lq4h0',) ./dispatch terminated with 1
ERROR:jhack.simulate_event:stdout=b'sh: 1: Syntax error: "(" unexpected\r\n'
ERROR:jhack.simulate_event:stderr=b'ERROR command terminated with exit code 2\n'
Fired secret-rotate on database/0.
```