### PR TITLE
Integrate fix

### DIFF
--- a/jhack/tests/utils/test_replay_local_runtime.py
+++ b/jhack/tests/utils/test_replay_local_runtime.py
@@ -20,6 +20,8 @@ except ModuleNotFoundError:
 from ops.charm import CharmBase, CharmEvents
 from runtime import Runtime
 
+Runtime.install()
+
 MEMO_TOOLS_RESOURCES_FOLDER = Path(__file__).parent / "memo_tools_test_files"
 
 

--- a/jhack/tests/utils/test_tail.py
+++ b/jhack/tests/utils/test_tail.py
@@ -39,11 +39,11 @@ def _mock_emit(
 
 
 def mock_uniter_events_only(value: bool = True):
-    if value:
-        jhack.utils.tail_charms.model_loglevel = lambda: "WARNING"
-        # this will make the parser only try to match "unit.myapp/0.juju-log Emitting Juju event..".
-    else:
-        jhack.utils.tail_charms.model_loglevel = lambda: "TRACE"
+    def _mock_loglevel(model=None):
+        return "WARNING" if value else "TRACE"
+
+    jhack.utils.tail_charms.model_loglevel = _mock_loglevel
+    # this will make the parser only try to match "unit.myapp/0.juju-log Emitting Juju event..".
 
 
 MOCK_JDL = {

--- a/jhack/utils/integrate.py
+++ b/jhack/utils/integrate.py
@@ -231,9 +231,9 @@ class IntegrationMatrix:
         rendered_matrix = [
             [
                 self._render_cell(provider_idx=prov_idx, requirer_idx=req_idx)
-                for prov_idx in range(len(apps))
+                for req_idx in range(len(apps))
             ]
-            for req_idx in range(len(apps))
+            for prov_idx in range(len(apps))
         ]
 
         for app, row in zip(apps, rendered_matrix):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "jhack"
 # TODO: keep snapcraft.yaml in sync with version!
-version = "0.3.10"
+version = "0.3.11"
 authors = [
     { name = "Pietro Pasotti", email = "pietro.pasotti@canonical.com" }
 ]

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,7 +10,7 @@ architectures:
   - build-on: i386
 
 # TODO: keep pyproject in sync with version!
-version: '0.3.10'
+version: '0.3.11'
 summary: Cli tool packed with juju hacks.
 
 description: |


### PR DESCRIPTION
- adds a `-p` flag to include peer relations in the matrix listing
- before: only the number of relations over an endpoint/interface would be shown. Now: you will see, for each endpoint, its interface and whether it's related to some remote endpoint. 
- minor style tweaks

![image](https://user-images.githubusercontent.com/6230162/220392033-6ed435ce-a36f-4855-a90f-99c0a8cd1bb8.png)


Fixes #54 