### PR TITLE
fix(tail): Restore cursor after empty 'tail' session

### DIFF
--- a/jhack/utils/tail_charms.py
+++ b/jhack/utils/tail_charms.py
@@ -952,7 +952,6 @@ class Processor:
         table_centered = Align.center(table)
         self.live.update(table_centered)
         self.live.refresh()
-        self.live.stop()
 
     def update_if_empty(self):
         if self._rendered:
@@ -1197,6 +1196,7 @@ def _tail_events(
         pass  # quit
     finally:
         processor.quit()
+        processor.live.stop()
 
     return processor  # for testing
 


### PR DESCRIPTION
When running `jhack tail` and keyboard-interrupting the session without any events observed, `live.stop()` will
never be called, resulting in the terminal cursor state to get corrupted (cursor is hidden in shell).
    
Fix this by moving the call to `live.stop()` to the `finally` block, so that it will always be called.

The cause of this bug is that `processor.quit()` has an early exit that ended up never calling `live.stop()`:

```python
if not self._rendered:
    self.live.update("No events caught.", refresh=True)
    return
```

(alternatively, `self.live.stop()` could be called before the `return` in the `if not self._rendered` block)

The `rich.live.Live` object [could be used as a context manager](https://rich.readthedocs.io/en/stable/live.html#basic-usage) to avoid having to call `.stop()` explicitly, but for this fix I opted for a minimally-intrusive change. One could create a context manager scope with a `Live` object in `_tail_events()` and pass that into `Processor`'s constructor (and move initialization of `console` and `color` out of it, most likely).